### PR TITLE
resource request parameter and audience in access token

### DIFF
--- a/apps/admin-ui/public/resources/en/realm-settings-help.json
+++ b/apps/admin-ui/public/resources/en/realm-settings-help.json
@@ -66,6 +66,7 @@
   "clientLoginTimeout": "Max time a client has to finish the access token protocol. This should normally be 1 minute.",
   "userInitiatedActionLifespan": "Maximum time before an action permit sent by a user (such as a forgot password e-mail) is expired. This value is recommended to be short because it's expected that the user would react to self-created action quickly.",
   "defaultAdminInitiatedActionLifespan": "Maximum time before an action permit sent to a user by administrator is expired. This value is recommended to be long to allow administrators to send e-mails for users that are currently offline. The default timeout can be overridden immediately before issuing the token.",
+  "defaultAudValueTooltip": "Default optional aud value for access token. If resource parameter is not present, aud claim is set equal to this value. Extra aud claim values can be added with Audience and AudienceResolver protocol mappers.",
   "overrideActionTokens": "Override default settings of maximum time before an action permit sent by a user (such as a forgot password e-mail) is expired for specific action. This value is recommended to be short because it's expected that the user would react to self-created action quickly.",
   "internationalization": "If enabled, you can choose which locales you support for this realm and which locale is the default.",
   "supportedLocales": "The locales to support for this realm. The user chooses one of these locales on the login screen.",

--- a/apps/admin-ui/public/resources/en/realm-settings.json
+++ b/apps/admin-ui/public/resources/en/realm-settings.json
@@ -203,6 +203,7 @@
   "clientLoginTimeout": "Client Login Timeout",
   "userInitiatedActionLifespan": "User-Initiated Action Lifespan",
   "defaultAdminInitiated": "Default Admin-Initiated Action Lifespan",
+  "defaultAudValue": "Default aud value for access token",
   "emailVerification": "Email Verification",
   "idpAccountEmailVerification": "IdP account email verification",
   "executeActions": "Execute actions",

--- a/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -19,6 +19,7 @@ import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/r
 import { FormAccess } from "../components/form-access/FormAccess";
 import { HelpItem } from "../components/help-enabler/HelpItem";
 import { FormPanel } from "../components/scroll-form/FormPanel";
+import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
 import {
   TimeSelector,
   toHumanFormat,
@@ -398,6 +399,30 @@ export const RealmSettingsTokensTab = ({
                   value={value}
                   onChange={onChange}
                   units={["minute", "hour", "day"]}
+                />
+              )}
+            />
+          </FormGroup>
+          <FormGroup
+            label={t("defaultAudValue")}
+            fieldId="defaultAudValue"
+            labelIcon={
+              <HelpItem
+                helpText="realm-settings-help:defaultAudValueTooltip"
+                fieldLabelId="realm-settings:defaultAudValue"
+              />
+            }
+          >
+            <Controller
+              name="defaultAudValueForAccessToken"
+              defaultValue=""
+              control={form.control}
+              render={({ onChange, value }) => (
+                <KeycloakTextInput
+                  id="defaultAudValue"
+                  value={value}
+                  onChange={onChange}
+                  placeholder={t("defaultAudValue")}
                 />
               )}
             />


### PR DESCRIPTION
## Motivation
Related to https://github.com/keycloak/keycloak/issues/13614.
keycloak related PR: https://github.com/keycloak/keycloak/pull/13622 ( working only with it)

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
![defaultAudAdminConsole](https://user-images.githubusercontent.com/55974447/183618115-77ddef38-72f0-4eec-b81b-cecd79135311.PNG)

