### PR TITLE
Show error message if application bootstrapping fails

### DIFF
--- a/src/AppError.tsx
+++ b/src/AppError.tsx
@@ -1,0 +1,5 @@
+import { FunctionComponent } from "react";
+
+export const AppError: FunctionComponent = () => {
+  return <h1>Something went wrong</h1>;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,22 +4,41 @@ import "@patternfly/react-core/dist/styles/base.css";
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
-import { App } from "./App";
+import { AdminClientProps, App } from "./App";
+import { AppError } from "./AppError";
 import { initAdminClient } from "./context/auth/AdminClient";
 import { initI18n } from "./i18n";
 
 import "./index.css";
 
+const root = document.getElementById("app");
+
 async function initialize() {
-  const { keycloak, adminClient } = await initAdminClient();
+  try {
+    const { keycloak, adminClient } = await initAdminClient();
 
-  await initI18n(adminClient);
+    await initI18n(adminClient);
+    renderApp({ keycloak, adminClient });
+  } catch (err) {
+    renderError();
+  }
+}
 
+function renderApp(props: AdminClientProps) {
   ReactDOM.render(
     <StrictMode>
-      <App keycloak={keycloak} adminClient={adminClient} />
+      <App {...props} />
     </StrictMode>,
-    document.getElementById("app")
+    root
+  );
+}
+
+function renderError() {
+  ReactDOM.render(
+    <StrictMode>
+      <AppError />
+    </StrictMode>,
+    root
   );
 }
 


### PR DESCRIPTION
Some users have [been reporting](https://groups.google.com/g/keycloak-user/c/3uim02zn1wU) blank pages when the Admin UI loads in. This PR adds some error handling in the bootstrapping process of the application to handle unexpected errors and shows an error page instead.