### PR TITLE
added translation for OIDC choices for Client authentication

### DIFF
--- a/public/resources/en/identity-providers.json
+++ b/public/resources/en/identity-providers.json
@@ -111,10 +111,10 @@
   },
   "clientAuthentication": "Client authentication",
   "clientAuthentications": {
-    "clientAuth_post": "Client secret sent as post",
-    "clientAuth_basic": "Client secret sent as basic auth",
-    "clientAuth_secret_jwt": "Client secret as jwt",
-    "clientAuth_privatekey_jwt": "JWT signed with private key"
+    "client_secret_post": "Client secret sent as post",
+    "client_secret_basic": "Client secret sent as basic auth",
+    "client_secret_jwt": "Client secret as jwt",
+    "private_key_jwt": "JWT signed with private key"
   },
   "acceptsPromptNone": "Accepts prompt=none forward from client",
   "validateSignature": "Validate Signatures",

--- a/src/identity-providers/add/OIDCAuthentication.tsx
+++ b/src/identity-providers/add/OIDCAuthentication.tsx
@@ -11,18 +11,19 @@ import {
 import { ClientIdSecret } from "../component/ClientIdSecret";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 
+const clientAuthentications = [
+  "clientAuth_post",
+  "clientAuth_basic",
+  "clientAuth_secret_jwt",
+  "clientAuth_privatekey_jwt",
+];
+
 export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {
   const { t } = useTranslation("identity-providers");
 
   const { control } = useFormContext();
   const [openClientAuth, setOpenClientAuth] = useState(false);
 
-  const clientAuthentications = [
-    "clientAuth_post",
-    "clientAuth_basic",
-    "clientAuth_secret_jwt",
-    "clientAuth_privatekey_jwt",
-  ];
   const clientAuthMethod = useWatch({
     control: control,
     name: "config.clientAuthMethod",
@@ -53,7 +54,7 @@ export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {
                 onChange(value as string);
                 setOpenClientAuth(false);
               }}
-              selections={t(`${value}`)}
+              selections={value}
               variant={SelectVariant.single}
               aria-label={t("clientAuthentication")}
               isOpen={openClientAuth}

--- a/src/identity-providers/add/OIDCAuthentication.tsx
+++ b/src/identity-providers/add/OIDCAuthentication.tsx
@@ -12,10 +12,10 @@ import { ClientIdSecret } from "../component/ClientIdSecret";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 
 const clientAuthentications = [
-  "clientAuth_post",
-  "clientAuth_basic",
-  "clientAuth_secret_jwt",
-  "clientAuth_privatekey_jwt",
+  "client_secret_post",
+  "client_secret_basic",
+  "client_secret_jwt",
+  "private_key_jwt",
 ];
 
 export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {

--- a/src/identity-providers/add/OIDCAuthentication.tsx
+++ b/src/identity-providers/add/OIDCAuthentication.tsx
@@ -11,19 +11,18 @@ import {
 import { ClientIdSecret } from "../component/ClientIdSecret";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 
-const clientAuthenticationTypes = [
-  "client_secret_post",
-  "client_secret_basic",
-  "client_secret_jwt",
-  "private_key_jwt",
-];
-
 export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {
   const { t } = useTranslation("identity-providers");
 
   const { control } = useFormContext();
   const [openClientAuth, setOpenClientAuth] = useState(false);
 
+  const clientAuthentications = [
+    "clientAuth_post",
+    "clientAuth_basic",
+    "clientAuth_secret_jwt",
+    "clientAuth_privatekey_jwt",
+  ];
   const clientAuthMethod = useWatch({
     control: control,
     name: "config.clientAuthMethod",
@@ -42,24 +41,24 @@ export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {
         fieldId="clientAuthentication"
       >
         <Controller
-          name="config.clientAuthMethod"
-          defaultValue={clientAuthenticationTypes[0]}
+          name="config.clientAuthentications"
+          defaultValue={clientAuthentications[0]}
           control={control}
           render={({ onChange, value }) => (
             <Select
-              toggleId="clientAuthMethod"
+              toggleId="clientAuthentication"
               required
               onToggle={() => setOpenClientAuth(!openClientAuth)}
               onSelect={(_, value) => {
                 onChange(value as string);
                 setOpenClientAuth(false);
               }}
-              selections={value}
+              selections={t(`${value}`)}
               variant={SelectVariant.single}
-              aria-label={t("prompt")}
+              aria-label={t("clientAuthentication")}
               isOpen={openClientAuth}
             >
-              {clientAuthenticationTypes.map((option) => (
+              {clientAuthentications.map((option) => (
                 <SelectOption
                   selected={option === value}
                   key={option}


### PR DESCRIPTION
## Motivation
Fixes #3080 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
