### PR TITLE
Add compatibility package for React Router migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-hook-form": "^6.15.8",
         "react-i18next": "^11.18.3",
         "react-router-dom": "^5.3.3",
+        "react-router-dom-v5-compat": "^6.3.0",
         "use-react-router-breadcrumbs": "^2.0.2"
       },
       "devDependencies": {
@@ -11351,6 +11352,39 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-router-dom-v5-compat": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz",
+      "integrity": "sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==",
+      "dependencies": {
+        "history": "^5.3.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
+        "react-router-dom": "4 || 5"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/react-router/node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
@@ -21829,6 +21863,33 @@
         "react-router": "5.3.3",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-router-dom-v5-compat": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz",
+      "integrity": "sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==",
+      "requires": {
+        "history": "^5.3.0",
+        "react-router": "6.3.0"
+      },
+      "dependencies": {
+        "history": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+          "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+          "requires": {
+            "@babel/runtime": "^7.7.6"
+          }
+        },
+        "react-router": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+          "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+          "requires": {
+            "history": "^5.2.0"
+          }
+        }
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-hook-form": "^6.15.8",
     "react-i18next": "^11.18.3",
     "react-router-dom": "^5.3.3",
+    "react-router-dom-v5-compat": "^6.3.0",
     "use-react-router-breadcrumbs": "^2.0.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, Suspense } from "react";
 import { Page } from "@patternfly/react-core";
 import { HashRouter as Router, Route, Switch } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 import { ErrorBoundary } from "react-error-boundary";
 import type Keycloak from "keycloak-js";
 import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
@@ -37,21 +38,23 @@ const AppContexts: FunctionComponent<AdminClientProps> = ({
   adminClient,
 }) => (
   <Router>
-    <AdminClientContext.Provider value={{ keycloak, adminClient }}>
-      <WhoAmIContextProvider>
-        <RealmsProvider>
-          <RealmContextProvider>
-            <AccessContextProvider>
-              <Help>
-                <AlertProvider>
-                  <SubGroups>{children}</SubGroups>
-                </AlertProvider>
-              </Help>
-            </AccessContextProvider>
-          </RealmContextProvider>
-        </RealmsProvider>
-      </WhoAmIContextProvider>
-    </AdminClientContext.Provider>
+    <CompatRouter>
+      <AdminClientContext.Provider value={{ keycloak, adminClient }}>
+        <WhoAmIContextProvider>
+          <RealmsProvider>
+            <RealmContextProvider>
+              <AccessContextProvider>
+                <Help>
+                  <AlertProvider>
+                    <SubGroups>{children}</SubGroups>
+                  </AlertProvider>
+                </Help>
+              </AccessContextProvider>
+            </RealmContextProvider>
+          </RealmsProvider>
+        </WhoAmIContextProvider>
+      </AdminClientContext.Provider>
+    </CompatRouter>
   </Router>
 );
 


### PR DESCRIPTION
Adds the compatibility package that allows usage of React Router v5 and v6 APIs. This will allow us to migrate to a newer version of React Router whilst maintaining backwards compatibility so code can be changed incrementally.

More information can be found in the [official migration guide](https://github.com/remix-run/react-router/discussions/8753).