### PR TITLE
Apply migrations for React Router 5.1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,11 +99,12 @@ export const App = ({ keycloak, adminClient }: AdminClientProps) => {
             <Switch>
               {routes.map((route, i) => (
                 <Route
-                  exact={route.matchOptions?.exact ?? true}
                   key={i}
                   path={route.path}
-                  component={() => <SecuredRoute route={route} />}
-                />
+                  exact={route.matchOptions?.exact ?? true}
+                >
+                  <SecuredRoute route={route} />
+                </Route>
               ))}
             </Switch>
           </ServerInfoProvider>


### PR DESCRIPTION
Applies the [migrations](https://reactrouter.com/docs/en/v6/upgrading/v5#upgrade-to-react-router-v51) for React Router version 5.1, which are required for the upgrade to version 6. Since we were already mostly using the hooks API the changes we need to make are very small.