### PR TITLE
Use CompatRoute for routes that can be migrated

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
 import { FunctionComponent, Suspense } from "react";
 import { Page } from "@patternfly/react-core";
-import { HashRouter as Router, Route, Switch } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import {
+  HashRouter as Router,
+  Route as LegacyRoute,
+  Switch,
+} from "react-router-dom";
+import { CompatRouter, CompatRoute } from "react-router-dom-v5-compat";
 import { ErrorBoundary } from "react-error-boundary";
 import type Keycloak from "keycloak-js";
 import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
@@ -97,15 +101,19 @@ export const App = ({ keycloak, adminClient }: AdminClientProps) => {
         >
           <ServerInfoProvider>
             <Switch>
-              {routes.map((route, i) => (
-                <Route
-                  key={i}
-                  path={route.path}
-                  exact={route.matchOptions?.exact ?? true}
-                >
-                  <SecuredRoute route={route} />
-                </Route>
-              ))}
+              {routes.map((route, i) => {
+                const Route = route.legacy ? LegacyRoute : CompatRoute;
+
+                return (
+                  <Route
+                    key={i}
+                    path={route.path}
+                    exact={route.matchOptions?.exact ?? true}
+                  >
+                    <SecuredRoute route={route} />
+                  </Route>
+                );
+              })}
             </Switch>
           </ServerInfoProvider>
         </ErrorBoundary>

--- a/src/authentication/routes/Authentication.ts
+++ b/src/authentication/routes/Authentication.ts
@@ -12,6 +12,7 @@ export const AuthenticationRoute: RouteDef = {
   component: lazy(() => import("../AuthenticationSection")),
   breadcrumb: (t) => t("authentication"),
   access: ["view-realm", "view-identity-providers", "view-clients"],
+  legacy: true,
 };
 
 export const toAuthentication = (

--- a/src/authentication/routes/Flow.ts
+++ b/src/authentication/routes/Flow.ts
@@ -15,6 +15,7 @@ export const FlowRoute: RouteDef = {
   component: lazy(() => import("../FlowDetails")),
   breadcrumb: (t) => t("authentication:flowDetails"),
   access: "view-authorization",
+  legacy: true,
 };
 
 export const toFlow = (params: FlowParams): LocationDescriptorObject => ({

--- a/src/client-scopes/routes/ClientScope.ts
+++ b/src/client-scopes/routes/ClientScope.ts
@@ -17,6 +17,7 @@ export const ClientScopeRoute: RouteDef = {
   component: lazy(() => import("../form/ClientScopeForm")),
   breadcrumb: (t) => t("client-scopes:clientScopeDetails"),
   access: "view-clients",
+  legacy: true,
 };
 
 export const toClientScope = (

--- a/src/clients/routes/Clients.ts
+++ b/src/clients/routes/Clients.ts
@@ -15,6 +15,7 @@ export const ClientsRoute: RouteDef = {
   component: lazy(() => import("../ClientsSection")),
   breadcrumb: (t) => t("clients:clientList"),
   access: "query-clients",
+  legacy: true,
 };
 
 export const toClients = (params: ClientsParams): LocationDescriptorObject => ({

--- a/src/clients/routes/DedicatedScopeDetails.ts
+++ b/src/clients/routes/DedicatedScopeDetails.ts
@@ -16,6 +16,7 @@ export const DedicatedScopeDetailsRoute: RouteDef = {
   component: lazy(() => import("../scopes/DedicatedScopes")),
   breadcrumb: (t) => t("clients:dedicatedScopes"),
   access: "view-clients",
+  legacy: true,
 };
 
 export const toDedicatedScope = (

--- a/src/clients/routes/NewPermission.ts
+++ b/src/clients/routes/NewPermission.ts
@@ -17,6 +17,7 @@ export const NewPermissionRoute: RouteDef = {
   component: lazy(() => import("../authorization/PermissionDetails")),
   breadcrumb: (t) => t("clients:createPermission"),
   access: "view-clients",
+  legacy: true,
 };
 
 export const toNewPermission = (

--- a/src/clients/routes/Resource.ts
+++ b/src/clients/routes/Resource.ts
@@ -14,6 +14,7 @@ export const ResourceDetailsRoute: RouteDef = {
   component: lazy(() => import("../authorization/ResourceDetails")),
   breadcrumb: (t) => t("clients:createResource"),
   access: "view-clients",
+  legacy: true,
 };
 
 export const toResourceDetails = (

--- a/src/clients/routes/Scope.ts
+++ b/src/clients/routes/Scope.ts
@@ -14,6 +14,7 @@ export const ScopeDetailsRoute: RouteDef = {
   component: lazy(() => import("../authorization/ScopeDetails")),
   breadcrumb: (t) => t("clients:createAuthorizationScope"),
   access: "manage-clients",
+  legacy: true,
 };
 
 export const toScopeDetails = (

--- a/src/dashboard/routes/Dashboard.ts
+++ b/src/dashboard/routes/Dashboard.ts
@@ -12,6 +12,7 @@ export const DashboardRoute: RouteDef = {
   component: lazy(() => import("../Dashboard")),
   breadcrumb: (t) => t("common:home"),
   access: "anyone",
+  legacy: true,
 };
 
 export const toDashboard = (

--- a/src/events/routes/Events.ts
+++ b/src/events/routes/Events.ts
@@ -15,6 +15,7 @@ export const EventsRoute: RouteDef = {
   component: lazy(() => import("../EventsSection")),
   breadcrumb: (t) => t("events:title"),
   access: "view-events",
+  legacy: true,
 };
 
 export const toEvents = (params: EventsParams): LocationDescriptorObject => ({

--- a/src/groups/routes/Groups.tsx
+++ b/src/groups/routes/Groups.tsx
@@ -12,6 +12,7 @@ export const GroupsRoute: RouteDef = {
   matchOptions: {
     exact: false,
   },
+  legacy: true,
 };
 
 export const toGroups = (params: GroupsParams): LocationDescriptorObject => ({

--- a/src/realm-roles/routes/ClientRole.ts
+++ b/src/realm-roles/routes/ClientRole.ts
@@ -21,6 +21,7 @@ export const ClientRoleRoute: RouteDef = {
   component: lazy(() => import("../RealmRoleTabs")),
   breadcrumb: (t) => t("roles:roleDetails"),
   access: "view-realm",
+  legacy: true,
 };
 
 export const toClientRole = (

--- a/src/realm-roles/routes/RealmRole.ts
+++ b/src/realm-roles/routes/RealmRole.ts
@@ -20,6 +20,7 @@ export const RealmRoleRoute: RouteDef = {
   component: lazy(() => import("../RealmRoleTabs")),
   breadcrumb: (t) => t("roles:roleDetails"),
   access: ["view-realm", "view-users"],
+  legacy: true,
 };
 
 export const toRealmRole = (

--- a/src/realm-settings/routes/AddCondition.ts
+++ b/src/realm-settings/routes/AddCondition.ts
@@ -13,6 +13,7 @@ export const NewClientPolicyConditionRoute: RouteDef = {
   component: lazy(() => import("../NewClientPolicyCondition")),
   breadcrumb: (t) => t("realm-settings:addCondition"),
   access: "manage-clients",
+  legacy: true,
 };
 
 export const toNewClientPolicyCondition = (

--- a/src/realm-settings/routes/EditCondition.ts
+++ b/src/realm-settings/routes/EditCondition.ts
@@ -14,6 +14,7 @@ export const EditClientPolicyConditionRoute: RouteDef = {
   component: lazy(() => import("../NewClientPolicyCondition")),
   breadcrumb: (t) => t("realm-settings:editCondition"),
   access: "manage-clients",
+  legacy: true,
 };
 
 export const toEditClientPolicyCondition = (

--- a/src/realm-settings/routes/RealmSettings.ts
+++ b/src/realm-settings/routes/RealmSettings.ts
@@ -28,6 +28,7 @@ export const RealmSettingsRoute: RouteDef = {
   component: lazy(() => import("../RealmSettingsSection")),
   breadcrumb: (t) => t("realmSettings"),
   access: "view-realm",
+  legacy: true,
 };
 
 export const toRealmSettings = (

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -23,6 +23,7 @@ export type RouteDef = {
   breadcrumb?: (t: TFunction) => string | ComponentType<any>;
   access: AccessType | AccessType[];
   matchOptions?: MatchOptions;
+  legacy?: boolean;
 };
 
 const NotFoundRoute: RouteDef = {

--- a/src/user-federation/routes/UserFederationLdap.ts
+++ b/src/user-federation/routes/UserFederationLdap.ts
@@ -16,6 +16,7 @@ export const UserFederationLdapRoute: RouteDef = {
   component: lazy(() => import("../UserFederationLdapSettings")),
   breadcrumb: (t) => t("common:settings"),
   access: "view-realm",
+  legacy: true,
 };
 
 export const toUserFederationLdap = (

--- a/src/user/routes/Users.ts
+++ b/src/user/routes/Users.ts
@@ -12,6 +12,7 @@ export const UsersRoute: RouteDef = {
   component: lazy(() => import("../UsersSection")),
   breadcrumb: (t) => t("users:title"),
   access: "query-users",
+  legacy: true,
 };
 
 export const toUsers = (params: UsersParams): LocationDescriptorObject => ({


### PR DESCRIPTION
Update all routes that can be migrated to version 6 of React Router to use the new API. Keeps routes that cannot be migrated directly under the old API by means of a boolean option called `legacy`.