### PR TITLE
Use 'useLocation' hook from v6 API of React Router

### DIFF
--- a/src/components/routable-tabs/RoutableTabs.tsx
+++ b/src/components/routable-tabs/RoutableTabs.tsx
@@ -11,7 +11,7 @@ import {
   JSXElementConstructor,
   ReactElement,
 } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom-v5-compat";
 
 // TODO: Remove the custom 'children' props and type once the following issue has been resolved:
 // https://github.com/patternfly/patternfly-react/issues/6766

--- a/src/groups/GroupAttributes.tsx
+++ b/src/groups/GroupAttributes.tsx
@@ -20,7 +20,7 @@ import { useAdminClient } from "../context/auth/AdminClient";
 
 import { getLastId } from "./groupIdUtils";
 import { useSubGroups } from "./SubGroupsContext";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom-v5-compat";
 
 export const GroupAttributes = () => {
   const { t } = useTranslation("groups");

--- a/src/groups/GroupTable.tsx
+++ b/src/groups/GroupTable.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import { cellWidth } from "@patternfly/react-table";
 

--- a/src/groups/GroupsSection.tsx
+++ b/src/groups/GroupsSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import {
   DropdownItem,

--- a/src/groups/Members.tsx
+++ b/src/groups/Members.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
+import { useLocation } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import { uniqBy } from "lodash-es";
 import {

--- a/src/groups/components/GroupTree.tsx
+++ b/src/groups/components/GroupTree.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { useLocation } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import {
   Dropdown,


### PR DESCRIPTION
Replaces usages of the 'useLocation' hook from React Router with the new version compatible with version 6, as per the [official migration guide](https://github.com/remix-run/react-router/discussions/8753).