### PR TITLE
Convert route definitions to React Router v6 APIs

### DIFF
--- a/src/authentication/routes/Authentication.ts
+++ b/src/authentication/routes/Authentication.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AuthenticationTab = "flows" | "required-actions" | "policies";
@@ -17,6 +17,6 @@ export const AuthenticationRoute: RouteDef = {
 
 export const toAuthentication = (
   params: AuthenticationParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(AuthenticationRoute.path, params),
 });

--- a/src/authentication/routes/CreateFlow.ts
+++ b/src/authentication/routes/CreateFlow.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type CreateFlowParams = { realm: string };
@@ -12,8 +12,6 @@ export const CreateFlowRoute: RouteDef = {
   access: "manage-authorization",
 };
 
-export const toCreateFlow = (
-  params: CreateFlowParams
-): LocationDescriptorObject => ({
+export const toCreateFlow = (params: CreateFlowParams): Partial<Path> => ({
   pathname: generatePath(CreateFlowRoute.path, params),
 });

--- a/src/authentication/routes/Flow.ts
+++ b/src/authentication/routes/Flow.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type FlowParams = {
@@ -18,6 +18,6 @@ export const FlowRoute: RouteDef = {
   legacy: true,
 };
 
-export const toFlow = (params: FlowParams): LocationDescriptorObject => ({
+export const toFlow = (params: FlowParams): Partial<Path> => ({
   pathname: generatePath(FlowRoute.path, params),
 });

--- a/src/client-scopes/details/MapperList.tsx
+++ b/src/client-scopes/details/MapperList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { LocationDescriptorObject } from "history";
+import type { Path } from "react-router-dom-v5-compat";
 import { Link } from "react-router-dom";
 import { Dropdown, DropdownItem, DropdownToggle } from "@patternfly/react-core";
 import { CaretDownIcon } from "@patternfly/react-icons";
@@ -21,7 +21,7 @@ type MapperListProps = {
     mappers: ProtocolMapperTypeRepresentation | ProtocolMapperRepresentation[]
   ) => void;
   onDelete: (mapper: ProtocolMapperRepresentation) => void;
-  detailLink: (id: string) => LocationDescriptorObject;
+  detailLink: (id: string) => Partial<Path>;
 };
 
 type Row = ProtocolMapperRepresentation & {

--- a/src/client-scopes/routes/ClientScope.ts
+++ b/src/client-scopes/routes/ClientScope.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientScopeTab = "settings" | "mappers" | "scope";
@@ -20,8 +20,6 @@ export const ClientScopeRoute: RouteDef = {
   legacy: true,
 };
 
-export const toClientScope = (
-  params: ClientScopeParams
-): LocationDescriptorObject => ({
+export const toClientScope = (params: ClientScopeParams): Partial<Path> => ({
   pathname: generatePath(ClientScopeRoute.path, params),
 });

--- a/src/client-scopes/routes/ClientScopes.ts
+++ b/src/client-scopes/routes/ClientScopes.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientScopesParams = { realm: string };
@@ -12,8 +12,6 @@ export const ClientScopesRoute: RouteDef = {
   access: "view-clients",
 };
 
-export const toClientScopes = (
-  params: ClientScopesParams
-): LocationDescriptorObject => ({
+export const toClientScopes = (params: ClientScopesParams): Partial<Path> => ({
   pathname: generatePath(ClientScopesRoute.path, params),
 });

--- a/src/client-scopes/routes/Mapper.ts
+++ b/src/client-scopes/routes/Mapper.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type MapperParams = {
@@ -17,6 +17,6 @@ export const MapperRoute: RouteDef = {
   access: "view-clients",
 };
 
-export const toMapper = (params: MapperParams): LocationDescriptorObject => ({
+export const toMapper = (params: MapperParams): Partial<Path> => ({
   pathname: generatePath(MapperRoute.path, params),
 });

--- a/src/client-scopes/routes/NewClientScope.ts
+++ b/src/client-scopes/routes/NewClientScope.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type NewClientScopeParams = { realm: string };
@@ -14,6 +14,6 @@ export const NewClientScopeRoute: RouteDef = {
 
 export const toNewClientScope = (
   params: NewClientScopeParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(NewClientScopeRoute.path, params),
 });

--- a/src/clients/authorization/DetailDescription.tsx
+++ b/src/clients/authorization/DetailDescription.tsx
@@ -1,11 +1,11 @@
-import { Link } from "react-router-dom";
-import type { LocationDescriptor } from "history";
-import { useTranslation } from "react-i18next";
 import {
+  DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  DescriptionListDescription,
 } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { Path } from "react-router-dom-v5-compat";
 
 type DetailDescriptionProps<T> = {
   name: string;
@@ -18,7 +18,7 @@ export function DetailDescription<T>(props: DetailDescriptionProps<T>) {
 }
 
 type DetailDescriptionLinkProps<T> = DetailDescriptionProps<T> & {
-  link?: (element: T) => LocationDescriptor;
+  link?: (element: T) => Partial<Path>;
 };
 
 export function DetailDescriptionLink<T>({

--- a/src/clients/routes/AddClient.ts
+++ b/src/clients/routes/AddClient.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddClientParams = { realm: string };
@@ -12,8 +12,6 @@ export const AddClientRoute: RouteDef = {
   access: "manage-clients",
 };
 
-export const toAddClient = (
-  params: AddClientParams
-): LocationDescriptorObject => ({
+export const toAddClient = (params: AddClientParams): Partial<Path> => ({
   pathname: generatePath(AddClientRoute.path, params),
 });

--- a/src/clients/routes/AuthenticationTab.ts
+++ b/src/clients/routes/AuthenticationTab.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AuthorizationTab =
@@ -26,6 +26,6 @@ export const AuthorizationRoute: RouteDef = {
 
 export const toAuthorizationTab = (
   params: AuthorizationParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(AuthorizationRoute.path, params),
 });

--- a/src/clients/routes/Client.ts
+++ b/src/clients/routes/Client.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientTab =
@@ -29,6 +29,6 @@ export const ClientRoute: RouteDef = {
   access: "query-clients",
 };
 
-export const toClient = (params: ClientParams): LocationDescriptorObject => ({
+export const toClient = (params: ClientParams): Partial<Path> => ({
   pathname: generatePath(ClientRoute.path, params),
 });

--- a/src/clients/routes/ClientScopeTab.ts
+++ b/src/clients/routes/ClientScopeTab.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientScopesTab = "setup" | "evaluate";
@@ -10,6 +10,7 @@ export type ClientScopesParams = {
   clientId: string;
   tab: ClientScopesTab;
 };
+
 export const ClientScopesRoute: RouteDef = {
   path: "/:realm/clients/:clientId/clientScopes/:tab",
   component: lazy(() => import("../ClientDetails")),
@@ -19,6 +20,6 @@ export const ClientScopesRoute: RouteDef = {
 
 export const toClientScopesTab = (
   params: ClientScopesParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(ClientScopesRoute.path, params),
 });

--- a/src/clients/routes/Clients.ts
+++ b/src/clients/routes/Clients.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientsTab = "list" | "initial-access-token";
@@ -18,6 +18,6 @@ export const ClientsRoute: RouteDef = {
   legacy: true,
 };
 
-export const toClients = (params: ClientsParams): LocationDescriptorObject => ({
+export const toClients = (params: ClientsParams): Partial<Path> => ({
   pathname: generatePath(ClientsRoute.path, params),
 });

--- a/src/clients/routes/CreateInitialAccessToken.ts
+++ b/src/clients/routes/CreateInitialAccessToken.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type CreateInitialAccessTokenParams = { realm: string };
@@ -14,6 +14,6 @@ export const CreateInitialAccessTokenRoute: RouteDef = {
 
 export const toCreateInitialAccessToken = (
   params: CreateInitialAccessTokenParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(CreateInitialAccessTokenRoute.path, params),
 });

--- a/src/clients/routes/DedicatedScopeDetails.ts
+++ b/src/clients/routes/DedicatedScopeDetails.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type DedicatedScopeTab = "mappers" | "scope";
@@ -21,6 +21,6 @@ export const DedicatedScopeDetailsRoute: RouteDef = {
 
 export const toDedicatedScope = (
   params: DedicatedScopeDetailsParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(DedicatedScopeDetailsRoute.path, params),
 });

--- a/src/clients/routes/ImportClient.ts
+++ b/src/clients/routes/ImportClient.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ImportClientParams = { realm: string };
@@ -12,8 +12,6 @@ export const ImportClientRoute: RouteDef = {
   access: "manage-clients",
 };
 
-export const toImportClient = (
-  params: ImportClientParams
-): LocationDescriptorObject => ({
+export const toImportClient = (params: ImportClientParams): Partial<Path> => ({
   pathname: generatePath(ImportClientRoute.path, params),
 });

--- a/src/clients/routes/Mapper.ts
+++ b/src/clients/routes/Mapper.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
 import { lazy } from "react";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type MapperParams = {
   realm: string;
@@ -16,6 +16,6 @@ export const MapperRoute: RouteDef = {
   access: "view-clients",
 };
 
-export const toMapper = (params: MapperParams): LocationDescriptorObject => ({
+export const toMapper = (params: MapperParams): Partial<Path> => ({
   pathname: generatePath(MapperRoute.path, params),
 });

--- a/src/clients/routes/NewPermission.ts
+++ b/src/clients/routes/NewPermission.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type PermissionType = "resource" | "scope";
 
@@ -22,6 +22,6 @@ export const NewPermissionRoute: RouteDef = {
 
 export const toNewPermission = (
   params: NewPermissionParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(NewPermissionRoute.path, params),
 });

--- a/src/clients/routes/NewPolicy.ts
+++ b/src/clients/routes/NewPolicy.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type NewPolicyParams = { realm: string; id: string; policyType: string };
 
@@ -12,8 +12,6 @@ export const NewPolicyRoute: RouteDef = {
   access: "view-clients",
 };
 
-export const toCreatePolicy = (
-  params: NewPolicyParams
-): LocationDescriptorObject => ({
+export const toCreatePolicy = (params: NewPolicyParams): Partial<Path> => ({
   pathname: generatePath(NewPolicyRoute.path, params),
 });

--- a/src/clients/routes/NewResource.ts
+++ b/src/clients/routes/NewResource.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type NewResourceParams = { realm: string; id: string };
 
@@ -12,8 +12,6 @@ export const NewResourceRoute: RouteDef = {
   access: "view-clients",
 };
 
-export const toCreateResource = (
-  params: NewResourceParams
-): LocationDescriptorObject => ({
+export const toCreateResource = (params: NewResourceParams): Partial<Path> => ({
   pathname: generatePath(NewResourceRoute.path, params),
 });

--- a/src/clients/routes/NewScope.ts
+++ b/src/clients/routes/NewScope.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type NewScopeParams = { realm: string; id: string };
 
@@ -12,8 +12,6 @@ export const NewScopeRoute: RouteDef = {
   access: "view-clients",
 };
 
-export const toNewScope = (
-  params: NewScopeParams
-): LocationDescriptorObject => ({
+export const toNewScope = (params: NewScopeParams): Partial<Path> => ({
   pathname: generatePath(NewScopeRoute.path, params),
 });

--- a/src/clients/routes/PermissionDetails.ts
+++ b/src/clients/routes/PermissionDetails.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 import type { PermissionType } from "./NewPermission";
 
 export type PermissionDetailsParams = {
@@ -20,6 +20,6 @@ export const PermissionDetailsRoute: RouteDef = {
 
 export const toPermissionDetails = (
   params: PermissionDetailsParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(PermissionDetailsRoute.path, params),
 });

--- a/src/clients/routes/PolicyDetails.ts
+++ b/src/clients/routes/PolicyDetails.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type PolicyDetailsParams = {
   realm: string;
@@ -19,6 +19,6 @@ export const PolicyDetailsRoute: RouteDef = {
 
 export const toPolicyDetails = (
   params: PolicyDetailsParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(PolicyDetailsRoute.path, params),
 });

--- a/src/clients/routes/Resource.ts
+++ b/src/clients/routes/Resource.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type ResourceDetailsParams = {
   realm: string;
@@ -19,6 +19,6 @@ export const ResourceDetailsRoute: RouteDef = {
 
 export const toResourceDetails = (
   params: ResourceDetailsParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(ResourceDetailsRoute.path, params),
 });

--- a/src/clients/routes/Scope.ts
+++ b/src/clients/routes/Scope.ts
@@ -1,7 +1,7 @@
-import type { LocationDescriptorObject } from "history";
-import type { RouteDef } from "../../route-config";
-import { generatePath } from "react-router-dom";
 import { lazy } from "react";
+import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import type { RouteDef } from "../../route-config";
 
 export type ScopeDetailsParams = {
   realm: string;
@@ -17,8 +17,6 @@ export const ScopeDetailsRoute: RouteDef = {
   legacy: true,
 };
 
-export const toScopeDetails = (
-  params: ScopeDetailsParams
-): LocationDescriptorObject => ({
+export const toScopeDetails = (params: ScopeDetailsParams): Partial<Path> => ({
   pathname: generatePath(ScopeDetailsRoute.path, params),
 });

--- a/src/components/routable-tabs/RoutableTabs.tsx
+++ b/src/components/routable-tabs/RoutableTabs.tsx
@@ -4,13 +4,14 @@ import {
   TabsComponent,
   TabsProps,
 } from "@patternfly/react-core";
-import type { History, LocationDescriptorObject } from "history";
+import type { History } from "history";
 import {
   Children,
   isValidElement,
   JSXElementConstructor,
   ReactElement,
 } from "react";
+import type { Path } from "react-router-dom-v5-compat";
 import { useLocation } from "react-router-dom-v5-compat";
 
 // TODO: Remove the custom 'children' props and type once the following issue has been resolved:
@@ -21,7 +22,7 @@ type Child = ChildElement | boolean | null | undefined;
 // TODO: Figure out why we need to omit 'ref' from the props.
 type RoutableTabsProps = {
   children: Child | Child[];
-  defaultLocation?: LocationDescriptorObject;
+  defaultLocation?: Partial<Path>;
 } & Omit<
   TabsProps,
   "ref" | "activeKey" | "defaultActiveKey" | "component" | "children"
@@ -67,7 +68,7 @@ export const RoutableTabs = ({
 };
 
 type RoutableTabParams = {
-  to: LocationDescriptorObject;
+  to: Partial<Path>;
   history: History<unknown>;
 };
 

--- a/src/dashboard/routes/Dashboard.ts
+++ b/src/dashboard/routes/Dashboard.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type DashboardTab = "info" | "providers";
@@ -15,8 +15,6 @@ export const DashboardRoute: RouteDef = {
   legacy: true,
 };
 
-export const toDashboard = (
-  params: DashboardParams
-): LocationDescriptorObject => ({
+export const toDashboard = (params: DashboardParams): Partial<Path> => ({
   pathname: generatePath(DashboardRoute.path, params),
 });

--- a/src/events/routes/Events.ts
+++ b/src/events/routes/Events.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type EventsTab = "user-events" | "admin-events";
@@ -18,6 +18,6 @@ export const EventsRoute: RouteDef = {
   legacy: true,
 };
 
-export const toEvents = (params: EventsParams): LocationDescriptorObject => ({
+export const toEvents = (params: EventsParams): Partial<Path> => ({
   pathname: generatePath(EventsRoute.path, params),
 });

--- a/src/groups/routes/Groups.tsx
+++ b/src/groups/routes/Groups.tsx
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type GroupsParams = { realm: string; id?: string };
@@ -15,6 +15,6 @@ export const GroupsRoute: RouteDef = {
   legacy: true,
 };
 
-export const toGroups = (params: GroupsParams): LocationDescriptorObject => ({
+export const toGroups = (params: GroupsParams): Partial<Path> => ({
   pathname: generatePath(GroupsRoute.path, params),
 });

--- a/src/groups/routes/GroupsSearch.tsx
+++ b/src/groups/routes/GroupsSearch.tsx
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type GroupsSearchParams = { realm: string };
@@ -12,8 +12,6 @@ export const GroupsSearchRoute: RouteDef = {
   access: "query-groups",
 };
 
-export const toGroupsSearch = (
-  params: GroupsSearchParams
-): LocationDescriptorObject => ({
+export const toGroupsSearch = (params: GroupsSearchParams): Partial<Path> => ({
   pathname: generatePath(GroupsSearchRoute.path, params),
 });

--- a/src/identity-providers/routes/AddMapper.ts
+++ b/src/identity-providers/routes/AddMapper.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProviderAddMapperParams = {
@@ -19,6 +19,6 @@ export const IdentityProviderAddMapperRoute: RouteDef = {
 
 export const toIdentityProviderAddMapper = (
   params: IdentityProviderAddMapperParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderAddMapperRoute.path, params),
 });

--- a/src/identity-providers/routes/EditMapper.ts
+++ b/src/identity-providers/routes/EditMapper.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProviderEditMapperParams = {
@@ -19,6 +19,6 @@ export const IdentityProviderEditMapperRoute: RouteDef = {
 
 export const toIdentityProviderEditMapper = (
   params: IdentityProviderEditMapperParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderEditMapperRoute.path, params),
 });

--- a/src/identity-providers/routes/IdentityProvider.ts
+++ b/src/identity-providers/routes/IdentityProvider.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 type IdentityProviderTabs = "settings" | "mappers";
@@ -21,6 +21,6 @@ export const IdentityProviderRoute: RouteDef = {
 
 export const toIdentityProvider = (
   params: IdentityProviderParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderRoute.path, params),
 });

--- a/src/identity-providers/routes/IdentityProviderCreate.ts
+++ b/src/identity-providers/routes/IdentityProviderCreate.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProviderCreateParams = {
@@ -17,6 +17,6 @@ export const IdentityProviderCreateRoute: RouteDef = {
 
 export const toIdentityProviderCreate = (
   params: IdentityProviderCreateParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderCreateRoute.path, params),
 });

--- a/src/identity-providers/routes/IdentityProviderKeycloakOidc.ts
+++ b/src/identity-providers/routes/IdentityProviderKeycloakOidc.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProviderKeycloakOidcParams = { realm: string };
@@ -14,6 +14,6 @@ export const IdentityProviderKeycloakOidcRoute: RouteDef = {
 
 export const toIdentityProviderKeycloakOidc = (
   params: IdentityProviderKeycloakOidcParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderKeycloakOidcRoute.path, params),
 });

--- a/src/identity-providers/routes/IdentityProviderOidc.ts
+++ b/src/identity-providers/routes/IdentityProviderOidc.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProviderOidcParams = { realm: string };
@@ -14,6 +14,6 @@ export const IdentityProviderOidcRoute: RouteDef = {
 
 export const toIdentityProviderOidc = (
   params: IdentityProviderOidcParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderOidcRoute.path, params),
 });

--- a/src/identity-providers/routes/IdentityProviderSaml.ts
+++ b/src/identity-providers/routes/IdentityProviderSaml.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProviderSamlParams = { realm: string };
@@ -14,6 +14,6 @@ export const IdentityProviderSamlRoute: RouteDef = {
 
 export const toIdentityProviderSaml = (
   params: IdentityProviderSamlParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProviderSamlRoute.path, params),
 });

--- a/src/identity-providers/routes/IdentityProviders.ts
+++ b/src/identity-providers/routes/IdentityProviders.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type IdentityProvidersParams = { realm: string };
@@ -14,6 +14,6 @@ export const IdentityProvidersRoute: RouteDef = {
 
 export const toIdentityProviders = (
   params: IdentityProvidersParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(IdentityProvidersRoute.path, params),
 });

--- a/src/realm-roles/routes/AddRole.ts
+++ b/src/realm-roles/routes/AddRole.ts
@@ -1,6 +1,6 @@
 import { lazy } from "react";
-import type { LocationDescriptorObject } from "history";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddRoleParams = { realm: string };
@@ -12,6 +12,6 @@ export const AddRoleRoute: RouteDef = {
   access: "manage-realm",
 };
 
-export const toAddRole = (params: AddRoleParams): LocationDescriptorObject => ({
+export const toAddRole = (params: AddRoleParams): Partial<Path> => ({
   pathname: generatePath(AddRoleRoute.path, params),
 });

--- a/src/realm-roles/routes/AddRoleToClient.ts
+++ b/src/realm-roles/routes/AddRoleToClient.ts
@@ -1,6 +1,6 @@
 import { lazy } from "react";
-import type { LocationDescriptorObject } from "history";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddRoleToClientParams = {
@@ -17,6 +17,6 @@ export const AddRoleToClientRoute: RouteDef = {
 
 export const toAddRoleToClient = (
   params: AddRoleToClientParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(AddRoleToClientRoute.path, params),
 });

--- a/src/realm-roles/routes/ClientRole.ts
+++ b/src/realm-roles/routes/ClientRole.ts
@@ -1,6 +1,6 @@
 import { lazy } from "react";
-import type { LocationDescriptorObject } from "history";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientRoleTab =
@@ -24,8 +24,6 @@ export const ClientRoleRoute: RouteDef = {
   legacy: true,
 };
 
-export const toClientRole = (
-  params: ClientRoleParams
-): LocationDescriptorObject => ({
+export const toClientRole = (params: ClientRoleParams): Partial<Path> => ({
   pathname: generatePath(ClientRoleRoute.path, params),
 });

--- a/src/realm-roles/routes/RealmRole.ts
+++ b/src/realm-roles/routes/RealmRole.ts
@@ -1,6 +1,6 @@
 import { lazy } from "react";
 import { generatePath } from "react-router";
-import type { LocationDescriptorObject } from "history";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type RealmRoleTab =
@@ -23,8 +23,6 @@ export const RealmRoleRoute: RouteDef = {
   legacy: true,
 };
 
-export const toRealmRole = (
-  params: RealmRoleParams
-): LocationDescriptorObject => ({
+export const toRealmRole = (params: RealmRoleParams): Partial<Path> => ({
   pathname: generatePath(RealmRoleRoute.path, params),
 });

--- a/src/realm-roles/routes/RealmRoles.ts
+++ b/src/realm-roles/routes/RealmRoles.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type RealmRolesParams = { realm: string };
@@ -12,8 +12,6 @@ export const RealmRolesRoute: RouteDef = {
   access: "view-realm",
 };
 
-export const toRealmRoles = (
-  params: RealmRolesParams
-): LocationDescriptorObject => ({
+export const toRealmRoles = (params: RealmRolesParams): Partial<Path> => ({
   pathname: generatePath(RealmRolesRoute.path, params),
 });

--- a/src/realm-settings/routes/AddAttribute.ts
+++ b/src/realm-settings/routes/AddAttribute.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddAttributeParams = {
@@ -14,8 +14,6 @@ export const AddAttributeRoute: RouteDef = {
   access: "manage-realm",
 };
 
-export const toAddAttribute = (
-  params: AddAttributeParams
-): LocationDescriptorObject => ({
+export const toAddAttribute = (params: AddAttributeParams): Partial<Path> => ({
   pathname: generatePath(AddAttributeRoute.path, params),
 });

--- a/src/realm-settings/routes/AddClientPolicy.ts
+++ b/src/realm-settings/routes/AddClientPolicy.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddClientPolicyParams = { realm: string };
@@ -14,6 +14,6 @@ export const AddClientPolicyRoute: RouteDef = {
 
 export const toAddClientPolicy = (
   params: AddClientPolicyParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(AddClientPolicyRoute.path, params),
 });

--- a/src/realm-settings/routes/AddClientProfile.ts
+++ b/src/realm-settings/routes/AddClientProfile.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddClientProfileParams = {
@@ -17,6 +17,6 @@ export const AddClientProfileRoute: RouteDef = {
 
 export const toAddClientProfile = (
   params: AddClientProfileParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(AddClientProfileRoute.path, params),
 });

--- a/src/realm-settings/routes/AddCondition.ts
+++ b/src/realm-settings/routes/AddCondition.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type NewClientPolicyConditionParams = {
@@ -18,6 +18,6 @@ export const NewClientPolicyConditionRoute: RouteDef = {
 
 export const toNewClientPolicyCondition = (
   params: NewClientPolicyConditionParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(NewClientPolicyConditionRoute.path, params),
 });

--- a/src/realm-settings/routes/AddExecutor.ts
+++ b/src/realm-settings/routes/AddExecutor.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddExecutorParams = {
@@ -15,8 +15,6 @@ export const AddExecutorRoute: RouteDef = {
   access: "manage-realm",
 };
 
-export const toAddExecutor = (
-  params: AddExecutorParams
-): LocationDescriptorObject => ({
+export const toAddExecutor = (params: AddExecutorParams): Partial<Path> => ({
   pathname: generatePath(AddExecutorRoute.path, params),
 });

--- a/src/realm-settings/routes/Attribute.ts
+++ b/src/realm-settings/routes/Attribute.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AttributeParams = {
@@ -15,8 +15,6 @@ export const AttributeRoute: RouteDef = {
   access: "manage-realm",
 };
 
-export const toAttribute = (
-  params: AttributeParams
-): LocationDescriptorObject => ({
+export const toAttribute = (params: AttributeParams): Partial<Path> => ({
   pathname: generatePath(AttributeRoute.path, params),
 });

--- a/src/realm-settings/routes/ClientPolicies.ts
+++ b/src/realm-settings/routes/ClientPolicies.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientPoliciesTab = "profiles" | "policies";
@@ -19,6 +19,6 @@ export const ClientPoliciesRoute: RouteDef = {
 
 export const toClientPolicies = (
   params: ClientPoliciesParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(ClientPoliciesRoute.path, params),
 });

--- a/src/realm-settings/routes/ClientProfile.ts
+++ b/src/realm-settings/routes/ClientProfile.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ClientProfileParams = {
@@ -17,6 +17,6 @@ export const ClientProfileRoute: RouteDef = {
 
 export const toClientProfile = (
   params: ClientProfileParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(ClientProfileRoute.path, params),
 });

--- a/src/realm-settings/routes/EditAttributesGroup.ts
+++ b/src/realm-settings/routes/EditAttributesGroup.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type EditAttributesGroupParams = {
@@ -17,6 +17,6 @@ export const EditAttributesGroupRoute: RouteDef = {
 
 export const toEditAttributesGroup = (
   params: EditAttributesGroupParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(EditAttributesGroupRoute.path, params),
 });

--- a/src/realm-settings/routes/EditClientPolicy.ts
+++ b/src/realm-settings/routes/EditClientPolicy.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type EditClientPolicyParams = {
@@ -17,6 +17,6 @@ export const EditClientPolicyRoute: RouteDef = {
 
 export const toEditClientPolicy = (
   params: EditClientPolicyParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(EditClientPolicyRoute.path, params),
 });

--- a/src/realm-settings/routes/EditCondition.ts
+++ b/src/realm-settings/routes/EditCondition.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type EditClientPolicyConditionParams = {
@@ -19,6 +19,6 @@ export const EditClientPolicyConditionRoute: RouteDef = {
 
 export const toEditClientPolicyCondition = (
   params: EditClientPolicyConditionParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(EditClientPolicyConditionRoute.path, params),
 });

--- a/src/realm-settings/routes/Executor.ts
+++ b/src/realm-settings/routes/Executor.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ExecutorParams = {
@@ -16,8 +16,6 @@ export const ExecutorRoute: RouteDef = {
   access: ["manage-realm"],
 };
 
-export const toExecutor = (
-  params: ExecutorParams
-): LocationDescriptorObject => ({
+export const toExecutor = (params: ExecutorParams): Partial<Path> => ({
   pathname: generatePath(ExecutorRoute.path, params),
 });

--- a/src/realm-settings/routes/KeyProvider.ts
+++ b/src/realm-settings/routes/KeyProvider.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ProviderType =
@@ -26,8 +26,6 @@ export const KeyProviderFormRoute: RouteDef = {
   access: "view-realm",
 };
 
-export const toKeyProvider = (
-  params: KeyProviderParams
-): LocationDescriptorObject => ({
+export const toKeyProvider = (params: KeyProviderParams): Partial<Path> => ({
   pathname: generatePath(KeyProviderFormRoute.path, params),
 });

--- a/src/realm-settings/routes/KeysTab.ts
+++ b/src/realm-settings/routes/KeysTab.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type KeySubTab = "list" | "providers";
@@ -17,6 +17,6 @@ export const KeysRoute: RouteDef = {
   access: "view-realm",
 };
 
-export const toKeysTab = (params: KeysParams): LocationDescriptorObject => ({
+export const toKeysTab = (params: KeysParams): Partial<Path> => ({
   pathname: generatePath(KeysRoute.path, params),
 });

--- a/src/realm-settings/routes/NewAttributesGroup.ts
+++ b/src/realm-settings/routes/NewAttributesGroup.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type NewAttributesGroupParams = {
@@ -16,6 +16,6 @@ export const NewAttributesGroupRoute: RouteDef = {
 
 export const toNewAttributesGroup = (
   params: NewAttributesGroupParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(NewAttributesGroupRoute.path, params),
 });

--- a/src/realm-settings/routes/RealmSettings.ts
+++ b/src/realm-settings/routes/RealmSettings.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type RealmSettingsTab =
@@ -33,6 +33,6 @@ export const RealmSettingsRoute: RouteDef = {
 
 export const toRealmSettings = (
   params: RealmSettingsParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(RealmSettingsRoute.path, params),
 });

--- a/src/realm-settings/routes/UserProfile.ts
+++ b/src/realm-settings/routes/UserProfile.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserProfileTab = "attributes" | "attributes-group" | "json-editor";
@@ -17,8 +17,6 @@ export const UserProfileRoute: RouteDef = {
   access: "view-realm",
 };
 
-export const toUserProfile = (
-  params: UserProfileParams
-): LocationDescriptorObject => ({
+export const toUserProfile = (params: UserProfileParams): Partial<Path> => ({
   pathname: generatePath(UserProfileRoute.path, params),
 });

--- a/src/realm/routes/AddRealm.ts
+++ b/src/realm/routes/AddRealm.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type AddRealmParams = { realm: string };
@@ -12,8 +12,6 @@ export const AddRealmRoute: RouteDef = {
   access: "view-realm",
 };
 
-export const toAddRealm = (
-  params: AddRealmParams
-): LocationDescriptorObject => ({
+export const toAddRealm = (params: AddRealmParams): Partial<Path> => ({
   pathname: generatePath(AddRealmRoute.path, params),
 });

--- a/src/sessions/routes/Sessions.ts
+++ b/src/sessions/routes/Sessions.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type SessionsParams = { realm: string };
@@ -12,8 +12,6 @@ export const SessionsRoute: RouteDef = {
   access: ["view-realm", "view-clients", "view-users"],
 };
 
-export const toSessions = (
-  params: SessionsParams
-): LocationDescriptorObject => ({
+export const toSessions = (params: SessionsParams): Partial<Path> => ({
   pathname: generatePath(SessionsRoute.path, params),
 });

--- a/src/user-federation/routes/NewKerberosUserFederation.ts
+++ b/src/user-federation/routes/NewKerberosUserFederation.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type NewKerberosUserFederationParams = { realm: string };
@@ -14,6 +14,6 @@ export const NewKerberosUserFederationRoute: RouteDef = {
 
 export const toNewKerberosUserFederation = (
   params: NewKerberosUserFederationParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(NewKerberosUserFederationRoute.path, params),
 });

--- a/src/user-federation/routes/NewLdapUserFederation.ts
+++ b/src/user-federation/routes/NewLdapUserFederation.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type NewLdapUserFederationParams = { realm: string };
@@ -15,6 +15,6 @@ export const NewLdapUserFederationRoute: RouteDef = {
 
 export const toNewLdapUserFederation = (
   params: NewLdapUserFederationParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(NewLdapUserFederationRoute.path, params),
 });

--- a/src/user-federation/routes/NewProvider.ts
+++ b/src/user-federation/routes/NewProvider.ts
@@ -1,7 +1,7 @@
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import { generatePath } from "react-router-dom-v5-compat";
 
-import type { LocationDescriptorObject } from "history";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type ProviderRouteParams = {
@@ -24,8 +24,6 @@ export const CustomEditProviderRoute: RouteDef = {
   access: "view-realm",
 };
 
-export const toProvider = (
-  params: ProviderRouteParams
-): LocationDescriptorObject => ({
+export const toProvider = (params: ProviderRouteParams): Partial<Path> => ({
   pathname: generatePath(CustomProviderRoute.path, params),
 });

--- a/src/user-federation/routes/UserFederation.ts
+++ b/src/user-federation/routes/UserFederation.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserFederationParams = { realm: string };
@@ -14,6 +14,6 @@ export const UserFederationRoute: RouteDef = {
 
 export const toUserFederation = (
   params: UserFederationParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(UserFederationRoute.path, params),
 });

--- a/src/user-federation/routes/UserFederationKerberos.ts
+++ b/src/user-federation/routes/UserFederationKerberos.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserFederationKerberosParams = {
@@ -17,6 +17,6 @@ export const UserFederationKerberosRoute: RouteDef = {
 
 export const toUserFederationKerberos = (
   params: UserFederationKerberosParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(UserFederationKerberosRoute.path, params),
 });

--- a/src/user-federation/routes/UserFederationLdap.ts
+++ b/src/user-federation/routes/UserFederationLdap.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 type UserFederationLdapTab = "settings" | "mappers";
@@ -21,6 +21,6 @@ export const UserFederationLdapRoute: RouteDef = {
 
 export const toUserFederationLdap = (
   params: UserFederationLdapParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(UserFederationLdapRoute.path, params),
 });

--- a/src/user-federation/routes/UserFederationLdapMapper.ts
+++ b/src/user-federation/routes/UserFederationLdapMapper.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserFederationLdapMapperParams = {
@@ -19,6 +19,6 @@ export const UserFederationLdapMapperRoute: RouteDef = {
 
 export const toUserFederationLdapMapper = (
   params: UserFederationLdapMapperParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(UserFederationLdapMapperRoute.path, params),
 });

--- a/src/user-federation/routes/UserFederationsKerberos.ts
+++ b/src/user-federation/routes/UserFederationsKerberos.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserFederationsKerberosParams = { realm: string };
@@ -13,6 +13,6 @@ export const UserFederationsKerberosRoute: RouteDef = {
 
 export const toUserFederationsKerberos = (
   params: UserFederationsKerberosParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(UserFederationsKerberosRoute.path, params),
 });

--- a/src/user-federation/routes/UserFederationsLdap.ts
+++ b/src/user-federation/routes/UserFederationsLdap.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserFederationsLdapParams = { realm: string };
@@ -13,6 +13,6 @@ export const UserFederationsLdapRoute: RouteDef = {
 
 export const toUserFederationsLdap = (
   params: UserFederationsLdapParams
-): LocationDescriptorObject => ({
+): Partial<Path> => ({
   pathname: generatePath(UserFederationsLdapRoute.path, params),
 });

--- a/src/user/routes/AddUser.ts
+++ b/src/user/routes/AddUser.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 
 import type { RouteDef } from "../../route-config";
 
@@ -13,6 +13,6 @@ export const AddUserRoute: RouteDef = {
   access: "manage-users",
 };
 
-export const toAddUser = (params: AddUserParams): LocationDescriptorObject => ({
+export const toAddUser = (params: AddUserParams): Partial<Path> => ({
   pathname: generatePath(AddUserRoute.path, params),
 });

--- a/src/user/routes/User.ts
+++ b/src/user/routes/User.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
-import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
+import { generatePath } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserTab =
@@ -23,6 +23,6 @@ export const UserRoute: RouteDef = {
   access: "query-users",
 };
 
-export const toUser = (params: UserParams): LocationDescriptorObject => ({
+export const toUser = (params: UserParams): Partial<Path> => ({
   pathname: generatePath(UserRoute.path, params),
 });

--- a/src/user/routes/Users.ts
+++ b/src/user/routes/Users.ts
@@ -1,6 +1,6 @@
-import type { LocationDescriptorObject } from "history";
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
+import type { Path } from "react-router-dom-v5-compat";
 import type { RouteDef } from "../../route-config";
 
 export type UserTab = "list" | "permissions";
@@ -15,6 +15,6 @@ export const UsersRoute: RouteDef = {
   legacy: true,
 };
 
-export const toUsers = (params: UsersParams): LocationDescriptorObject => ({
+export const toUsers = (params: UsersParams): Partial<Path> => ({
   pathname: generatePath(UsersRoute.path, params),
 });


### PR DESCRIPTION
Converts most of the route definitions over to the v6 API of React Router.