### PR TITLE
Do not display error when policy name is empty

### DIFF
--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -139,7 +139,7 @@ export default function NewClientPolicyForm() {
         <ViewHeader
           titleKey={
             showAddConditionsAndProfilesForm || policyName
-              ? formValues.name!
+              ? policyName
               : "realm-settings:createPolicy"
           }
           divider
@@ -537,7 +537,7 @@ export default function NewClientPolicyForm() {
                         {...props}
                         to={toNewClientPolicyCondition({
                           realm,
-                          policyName: formValues.name!,
+                          policyName: policyName!,
                         })}
                       ></Link>
                     )}


### PR DESCRIPTION
## Motivation
Closes #3138.

## Brief Description
I replace usage of value from form by using name received from URL

## Verification Steps

1. Go to `Realm settings >> Client policies`.
2. Create a new policy.
3. Edit the new policy and empty name value.

## Checklist:

- [X] Code has been tested locally by PR requester

## Additional Notes
I also change display of policy name in the header because it does not make any sense to check if `policyName` variable exists to display value from form
