### PR TITLE
Client policies > add condition: the initial help info of condition selector is not correct (Issue-1785) fix

### DIFF
--- a/src/realm-settings/NewClientPolicyCondition.tsx
+++ b/src/realm-settings/NewClientPolicyCondition.tsx
@@ -197,7 +197,7 @@ export default function NewClientPolicyCondition() {
                     ? `realm-settings-help:${camelCase(
                         conditionType.replace(/-/g, " ")
                       )}`
-                    : "realm-settings:anyClient"
+                    : "realm-settings-help:conditions"
                 }
                 fieldLabelId="realm-settings:conditionType"
               />

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -524,7 +524,7 @@ export default function NewClientPolicyForm() {
                   <Text className="kc-conditions" component={TextVariants.h1}>
                     {t("conditions")}
                     <HelpItem
-                      helpText="realm-settings:realm-settings-help:conditions"
+                      helpText="realm-settings-help:conditions"
                       fieldLabelId="realm-settings:conditions"
                     />
                   </Text>


### PR DESCRIPTION
## Motivation
see #1785

## Brief Description
fixed #1785

![image](https://user-images.githubusercontent.com/31955648/186169308-78358f55-1b34-477e-8b0c-31c4fe3bcb2f.png)


## Verification Steps
Realm settings -> client policies -> policy details -> add condition

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
The policy details had a similar bug, which I've included a fix in this pr. `realm-settings:conditions` text was just 'Condition', so I've used `realm-settings-help` instead

![image](https://user-images.githubusercontent.com/31955648/186169524-85be60cc-d112-488f-982b-20ac1dabf29a.png)
