### PR TITLE
Force refresh of user after save to avoid modal (#3180)

### DIFF
--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -46,6 +46,7 @@ const UsersTabs = () => {
   const [user, setUser] = useState<UserRepresentation>();
   const [bruteForced, setBruteForced] = useState<BruteForced>();
   const [addedGroups, setAddedGroups] = useState<GroupRepresentation[]>([]);
+  const [forceFetch, setForceFetch] = useState(false);
 
   useFetch(
     async () => {
@@ -72,7 +73,7 @@ const UsersTabs = () => {
       setBruteForced(bruteForced);
       user && setupForm(user);
     },
-    [user?.username]
+    [user?.username, forceFetch]
   );
 
   const setupForm = (user: UserRepresentation) => {
@@ -90,6 +91,7 @@ const UsersTabs = () => {
       if (id) {
         await adminClient.users.update({ id }, user);
         addAlert(t("userSaved"), AlertVariant.success);
+        setForceFetch(!forceFetch);
       } else {
         const createdUser = await adminClient.users.create(user);
 

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -74,7 +74,7 @@ const UsersTabs = () => {
       setBruteForced(bruteForced);
       user && setupForm(user);
     },
-    [user?.username, forceFetch]
+    [user?.username, refreshCount]
   );
 
   const setupForm = (user: UserRepresentation) => {

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -46,7 +46,8 @@ const UsersTabs = () => {
   const [user, setUser] = useState<UserRepresentation>();
   const [bruteForced, setBruteForced] = useState<BruteForced>();
   const [addedGroups, setAddedGroups] = useState<GroupRepresentation[]>([]);
-  const [forceFetch, setForceFetch] = useState(false);
+  const [refreshCount, setRefreshCount] = useState(0);
+  const refresh = () => setRefreshCount((count) => count + 1);
 
   useFetch(
     async () => {

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -92,7 +92,7 @@ const UsersTabs = () => {
       if (id) {
         await adminClient.users.update({ id }, user);
         addAlert(t("userSaved"), AlertVariant.success);
-        setForceFetch(!forceFetch);
+        refresh();
       } else {
         const createdUser = await adminClient.users.create(user);
 


### PR DESCRIPTION
## Motivation
Closes #3180 

## Brief Description
The problem is that field stay dirty after save, so I force refresh of user after an update. Maybe there is a better way to reset dirty field, for exemple display a spinner instead of form during save.

## Verification Steps
1. Update user firstname and save.
2. Switch to Attributes tab.
3. Do it once again if problem doesn't occurred.

## Checklist:

- [X] Code has been tested locally by PR requester

