### PR TITLE
added data cleaup after tests, fix for affected identity_providers_oi…

### DIFF
--- a/apps/admin-ui/cypress/e2e/users_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/users_test.spec.ts
@@ -236,9 +236,11 @@ describe("User creation", () => {
 
     after(async () => {
       await adminClient.deleteUser(usernameIdpLinksTest);
-      await Promise.all(identityProviders.map((idp) =>
-        adminClient.deleteIdentityProvider(idp.alias)
-      ));
+      await Promise.all(
+        identityProviders.map((idp) =>
+          adminClient.deleteIdentityProvider(idp.alias)
+        )
+      );
     });
 
     beforeEach(() => {

--- a/apps/admin-ui/cypress/e2e/users_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/users_test.spec.ts
@@ -235,10 +235,10 @@ describe("User creation", () => {
     });
 
     after(async () => {
-      adminClient.deleteUser(usernameIdpLinksTest);
-      identityProviders.forEach((idp) =>
+      await adminClient.deleteUser(usernameIdpLinksTest);
+      await Promise.all(identityProviders.map((idp) =>
         adminClient.deleteIdentityProvider(idp.alias)
-      );
+      ));
     });
 
     beforeEach(() => {

--- a/apps/admin-ui/cypress/e2e/users_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/users_test.spec.ts
@@ -234,7 +234,12 @@ describe("User creation", () => {
       ]);
     });
 
-    after(() => adminClient.deleteUser(usernameIdpLinksTest));
+    after(async () => {
+      adminClient.deleteUser(usernameIdpLinksTest);
+      identityProviders.forEach((idp) =>
+        adminClient.deleteIdentityProvider(idp.alias)
+      );
+    });
 
     beforeEach(() => {
       usersPage.goToUserListTab().goToUserDetailsPage(usernameIdpLinksTest);

--- a/apps/admin-ui/cypress/support/util/AdminClient.ts
+++ b/apps/admin-ui/cypress/support/util/AdminClient.ts
@@ -200,6 +200,13 @@ class AdminClient {
     });
   }
 
+  async deleteIdentityProvider(idpAlias: string) {
+    await this.login();
+    await this.client.identityProviders.del({
+      alias: idpAlias,
+    });
+  }
+
   async unlinkAccountIdentityProvider(
     username: string,
     idpDisplayName: string


### PR DESCRIPTION
Small fix for affected test in **identity_providers_oidc_test.spec.ts** 

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
