### PR TITLE
use avatar picture when it exists

### DIFF
--- a/apps/admin-ui/src/PageHeader.tsx
+++ b/apps/admin-ui/src/PageHeader.tsx
@@ -89,6 +89,8 @@ export const Header = () => {
   ];
 
   const headerTools = () => {
+    const adminClient = useAdminClient();
+    const picture = adminClient.keycloak.tokenParsed?.picture;
     return (
       <PageHeaderTools>
         <PageHeaderToolsGroup
@@ -120,7 +122,7 @@ export const Header = () => {
           </PageHeaderToolsItem>
         </PageHeaderToolsGroup>
         <Avatar
-          src={environment.resourceUrl + "/img_avatar.svg"}
+          src={picture || environment.resourceUrl + "/img_avatar.svg"}
           alt="Avatar image"
         />
       </PageHeaderTools>


### PR DESCRIPTION
The default mapper uses `picture` as field in the token so if it's there let's use that instead
![image](https://user-images.githubusercontent.com/51133/186836707-fd3a3c89-50a6-4a37-8638-ab64cf30cb1b.png)
I've used github as Idp:
![image](https://user-images.githubusercontent.com/51133/186837054-54454f78-b388-4ea1-8ae4-d3e9ec27ba33.png)
