### PR TITLE
Set Dependabot versioning strategy for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     open-pull-requests-limit: 999
     rebase-strategy: disabled
+    versioning-strategy: increase
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
Sets the Dependabot versioning strategy for NPM dependencies so that the package lockfile will also (hopefully) be updated. For more information see https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437.