### PR TITLE
Added missing manageOrderItemAria

### DIFF
--- a/apps/admin-ui/public/resources/en/identity-providers.json
+++ b/apps/admin-ui/public/resources/en/identity-providers.json
@@ -39,7 +39,6 @@
   "createError": "Could not create the identity provider: {{error}}",
   "orderDialogIntro": "The order that the providers are listed in the login page or the account console. You can drag the row handles to change the order.",
   "manageOrderTableAria": "List of identity providers in the order listed on the login page",
-  "manageOrderItemAria": "Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation.",
   "orderChangeSuccess": "Successfully changed display order of identity providers",
   "orderChangeError": "Could not change display order of identity providers {{error}}",
   "alias": "Alias",

--- a/apps/admin-ui/public/resources/en/user-federation.json
+++ b/apps/admin-ui/public/resources/en/user-federation.json
@@ -169,5 +169,6 @@
   "providerType": "Provider Type",
   "parentId": "Parent ID",
   "kerberosPrincipal": "Kerberos Principal",
-  "kerberosKeyTab": "Kerberos Key Tab"
+  "kerberosKeyTab": "Kerberos Key Tab",
+  "manageOrderItemAria": "Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
 }

--- a/apps/admin-ui/public/resources/en/user-federation.json
+++ b/apps/admin-ui/public/resources/en/user-federation.json
@@ -169,6 +169,5 @@
   "providerType": "Provider Type",
   "parentId": "Parent ID",
   "kerberosPrincipal": "Kerberos Principal",
-  "kerberosKeyTab": "Kerberos Key Tab",
-  "manageOrderItemAria": "Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+  "kerberosKeyTab": "Kerberos Key Tab"
 }

--- a/apps/admin-ui/src/identity-providers/ManageOrderDialog.tsx
+++ b/apps/admin-ui/src/identity-providers/ManageOrderDialog.tsx
@@ -120,7 +120,7 @@ export const ManageOrderDialog = ({
           >
             <DataListItemRow>
               <DataListControl>
-                <DataListDragButton aria-label={t("manageOrderItemAria")} />
+                <DataListDragButton aria-label={t("common-help:dragHelp")} />
               </DataListControl>
               <DataListItemCells
                 dataListCells={[

--- a/apps/admin-ui/src/user-federation/ManagePriorityDialog.tsx
+++ b/apps/admin-ui/src/user-federation/ManagePriorityDialog.tsx
@@ -121,7 +121,7 @@ export const ManagePriorityDialog = ({
           >
             <DataListItemRow>
               <DataListControl>
-                <DataListDragButton aria-label={t("manageOrderItemAria")} />
+                <DataListDragButton aria-label={t("common-help:dragHelp")} />
               </DataListControl>
               <DataListItemCells
                 dataListCells={[


### PR DESCRIPTION
## Motivation
Closes https://github.com/keycloak/keycloak-ui/issues/3216

## Verification Steps
1. Go to `User federation`.
2. Add provider.
3. Open Manage priorities dialog
4. Verify that the aria-label for the drag button is reading `Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation.`


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

