### PR TITLE
Allow edit username if we can't determine mutability.

### DIFF
--- a/apps/admin-ui/src/user/UserForm.tsx
+++ b/apps/admin-ui/src/user/UserForm.tsx
@@ -204,7 +204,11 @@ export const UserForm = ({
             id="kc-username"
             aria-label={t("username")}
             name="username"
-            isReadOnly={!!user?.id && !realm?.editUsernameAllowed}
+            isReadOnly={
+              !!user?.id &&
+              !realm?.editUsernameAllowed &&
+              realm?.editUsernameAllowed !== undefined
+            }
           />
         </FormGroup>
       )}


### PR DESCRIPTION
## Motivation
Fixes #1975 

## Brief Description
I think I have come up with a reasonable compromise.  I found that if `Edit username` is off and you go ahead and let the user try to change it, nothing bad will happen.  Other changes in the submission will go through, but it won't change the user name.

So in the rare case where a user doesn't have `view-realm` access, we can just allow the username field to be editable.  That way, the field is still properly enabled/disabled in most instances but doesn't do any harm if we can't determine mutability.  And then we don't need any weird changes on the back end.

## Verification Steps
See #1975

