### PR TITLE
Proposed fix for column with long field names #2073

### DIFF
--- a/apps/admin-ui/src/index.css
+++ b/apps/admin-ui/src/index.css
@@ -61,3 +61,7 @@ td.pf-c-table__check > input[type="checkbox"] {
   color: var(--pf-global--primary-color--100);
   width: fit-content;
 }
+
+.pf-c-form {
+  --pf-c-form--m-horizontal__group-label--md--GridColumnWidth: 12.375rem !important;
+}


### PR DESCRIPTION
## Motivation
Closes #2073 

I have investigated this issue. It really depends on how far we want to go with this. Every form in the app has this issue which is due to the patternfly .--pf-c-form--m-horizontal__group-label--md--GridColumnWidth set to `10.375rem` globally.

I can fix this particular issue, however, `Authorization details` in the `Clients > Client details > Authorization > Export` is not the longest form field name in our app. 

In order to fix all long-form names I'd need to change `--pf-c-form--m-horizontal__group-label--md--GridColumnWidth`  from `10.375rem` to something like `15.375rem` maybe even `16.375rem`. This would, however, result in a column with form field names wider than the input fields column.

The best is probably changing `--pf-c-form--m-horizontal__group-label--md--GridColumnWidth`  to `12.375rem`. This will not solve all issues but many including the reported `Authorization details` while still retaining the form's original look.

## Verification Steps
1. Go to `Clients`.
2. Selected created a client and go to `Authorization`
3. Select the `Export` tab
4. Verify that the question mark is now aligned with the tag `Authorization details`

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
