### PR TITLE
Fix Keycloak OpenID Connect Identity provider creation

### DIFF
--- a/apps/admin-ui/src/identity-providers/add/AddOpenIdConnect.tsx
+++ b/apps/admin-ui/src/identity-providers/add/AddOpenIdConnect.tsx
@@ -29,7 +29,7 @@ export default function AddOpenIdConnect() {
   const { t } = useTranslation("identity-providers");
   const navigate = useNavigate();
   const { url } = useRouteMatch();
-  const isKeycloak = url.endsWith("keycloak-oidc");
+  const isKeycloak = url.includes("keycloak-oidc");
   const id = `${isKeycloak ? "keycloak-" : ""}oidc`;
 
   const form = useForm<IdentityProviderRepresentation>({


### PR DESCRIPTION
## Motivation
Closes #3252 

## Brief Description
When creating a Keycloak OpenID Connect Identity Provider, the providerId is set to 'oidc' instead of 'keycloak-oidc', resulting in unexpected behavior.

## Verification Steps
1. Master Realm > Identity Providers
2. Select 'Keycloak OpenID Connect'. If there are already IdPs created: Click 'Add provider' dropdown, select 'Keycloak OpenID Connect'
4. Confirm that the header says 'Add Keycloak OpenID Connect provider' instead of 'Add OpenID Connect provider'
5. Fill out form, save.
6. Go back to Master Realm > Identity Providers
7. Confirm the "Provider details" for the provider created says "Keycloak-oidc" instead of "oidc"

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
