### PR TITLE
Optimize dependencies with Rollup

### DIFF
--- a/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -188,11 +188,11 @@ describe("Clients test", () => {
       commonPage.tableUtils().checkRowItemExists(itemName, false);
     });
 
-    // TODO: https://github.com/keycloak/keycloak-admin-ui/issues/1854
     it("Should remove multiple client scopes from search bar", () => {
       const itemName1 = clientScopeName + 1;
       const itemName2 = clientScopeName + 2;
       commonPage.tableToolbarUtils().clickSearchButton();
+      waitForClientScopes();
       commonPage.tableToolbarUtils().checkActionItemIsEnabled("Remove", false);
       commonPage.tableToolbarUtils().searchItem(clientScopeName, false);
       commonPage
@@ -200,6 +200,7 @@ describe("Clients test", () => {
         .selectRowItemCheckbox(itemName1)
         .selectRowItemCheckbox(itemName2);
       commonPage.tableToolbarUtils().clickSearchButton();
+      waitForClientScopes();
       commonPage.tableToolbarUtils().clickActionItem("Remove");
       commonPage.masthead().checkNotificationMessage(msgScopeMappingRemoved);
       commonPage.tableToolbarUtils().searchItem(clientScopeName, false);
@@ -1002,3 +1003,8 @@ describe("Clients test", () => {
     });
   });
 });
+
+function waitForClientScopes() {
+  cy.intercept("/admin/realms/master/client-scopes").as("load");
+  cy.wait("@load");
+}

--- a/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -191,16 +191,20 @@ describe("Clients test", () => {
     it("Should remove multiple client scopes from search bar", () => {
       const itemName1 = clientScopeName + 1;
       const itemName2 = clientScopeName + 2;
+      cy.intercept("/admin/realms/master/client-scopes").as("load");
       commonPage.tableToolbarUtils().clickSearchButton();
-      waitForClientScopes();
+      cy.wait("@load");
+      cy.wait(1000);
       commonPage.tableToolbarUtils().checkActionItemIsEnabled("Remove", false);
       commonPage.tableToolbarUtils().searchItem(clientScopeName, false);
       commonPage
         .tableUtils()
         .selectRowItemCheckbox(itemName1)
         .selectRowItemCheckbox(itemName2);
+      cy.intercept("/admin/realms/master/client-scopes").as("load");
       commonPage.tableToolbarUtils().clickSearchButton();
-      waitForClientScopes();
+      cy.wait("@load");
+      cy.wait(1000);
       commonPage.tableToolbarUtils().clickActionItem("Remove");
       commonPage.masthead().checkNotificationMessage(msgScopeMappingRemoved);
       commonPage.tableToolbarUtils().searchItem(clientScopeName, false);
@@ -1003,8 +1007,3 @@ describe("Clients test", () => {
     });
   });
 });
-
-function waitForClientScopes() {
-  cy.intercept("/admin/realms/master/client-scopes").as("load");
-  cy.wait("@load");
-}

--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -28,6 +28,7 @@
     "lodash-es": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-dropzone": "^14.2.2",
     "react-error-boundary": "^3.1.4",
     "react-flow-renderer": "^9.7.4",
     "react-hook-form": "^6.15.8",

--- a/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
+++ b/apps/admin-ui/src/clients/keys/GenerateKeyDialog.tsx
@@ -9,7 +9,6 @@ import {
 import {
   Button,
   ButtonVariant,
-  FileUpload,
   Form,
   FormGroup,
   Modal,
@@ -24,6 +23,7 @@ import {
 import type KeyStoreConfig from "@keycloak/keycloak-admin-client/lib/defs/keystoreConfig";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { StoreSettings } from "./StoreSettings";
+import { FileUpload } from "../../components/json-file-upload/patternfly/FileUpload";
 
 type GenerateKeyDialogProps = {
   clientId: string;

--- a/apps/admin-ui/src/clients/keys/ImportKeyDialog.tsx
+++ b/apps/admin-ui/src/clients/keys/ImportKeyDialog.tsx
@@ -4,7 +4,6 @@ import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import {
   Button,
   ButtonVariant,
-  FileUpload,
   Form,
   FormGroup,
   Modal,
@@ -17,6 +16,7 @@ import {
 } from "@patternfly/react-core";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { StoreSettings } from "./StoreSettings";
+import { FileUpload } from "../../components/json-file-upload/patternfly/FileUpload";
 
 type ImportKeyDialogProps = {
   toggleDialog: () => void;

--- a/apps/admin-ui/src/components/dynamic/FileComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/FileComponent.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
-import { FileUpload, FormGroup } from "@patternfly/react-core";
+import { FormGroup } from "@patternfly/react-core";
 
 import { HelpItem } from "../help-enabler/HelpItem";
 import type { ComponentProps } from "./components";
 import { convertToName } from "./DynamicComponents";
+import { FileUpload } from "../json-file-upload/patternfly/FileUpload";
 
 export const FileComponent = ({
   name,

--- a/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
@@ -5,8 +5,10 @@ import {
   useState,
 } from "react";
 import { FormGroup, Modal, ModalVariant, Button } from "@patternfly/react-core";
+import { DropEvent } from "react-dropzone";
 import { useTranslation } from "react-i18next";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
+
 import { FileUpload, FileUploadProps } from "./patternfly/FileUpload";
 
 type FileUploadType = {
@@ -48,24 +50,19 @@ export const FileUploadForm = ({
   };
   const [fileUpload, setFileUpload] = useState<FileUploadType>(defaultUpload);
   const removeDialog = () => setFileUpload({ ...fileUpload, modal: false });
-  const handleChange: FileUploadProps["onChange"] = (
-    value,
-    filename,
-    event
-  ) => {
-    if (event instanceof MouseEvent && !(event instanceof DragEvent)) {
-      setFileUpload({ ...fileUpload, modal: true });
-    } else {
-      setFileUpload({
-        ...fileUpload,
-        value: value.toString(),
-        filename,
-      });
 
-      if (value) {
-        onChange(value.toString());
-      }
-    }
+  const handleFileInputChange = (_event: DropEvent, file: File) => {
+    setFileUpload({ ...fileUpload, filename: file.name });
+  };
+
+  const handleTextOrDataChange = (value: string) => {
+    setFileUpload({ ...fileUpload, value });
+    onChange(value);
+  };
+
+  const handleClear = () => {
+    setFileUpload({ ...fileUpload, value: "", filename: "" });
+    onChange("");
   };
 
   return (
@@ -108,7 +105,10 @@ export const FileUploadForm = ({
           type="text"
           value={fileUpload.value}
           filename={fileUpload.filename}
-          onChange={handleChange}
+          onFileInputChange={handleFileInputChange}
+          onDataChange={handleTextOrDataChange}
+          onTextChange={handleTextOrDataChange}
+          onClearClick={handleClear}
           onReadStarted={() =>
             setFileUpload({ ...fileUpload, isLoading: true })
           }
@@ -133,7 +133,10 @@ export const FileUploadForm = ({
             type="text"
             value={fileUpload.value}
             filename={fileUpload.filename}
-            onChange={handleChange}
+            onFileInputChange={handleFileInputChange}
+            onDataChange={handleTextOrDataChange}
+            onTextChange={handleTextOrDataChange}
+            onClearClick={handleClear}
             onReadStarted={() =>
               setFileUpload({ ...fileUpload, isLoading: true })
             }
@@ -149,9 +152,7 @@ export const FileUploadForm = ({
                 code={fileUpload.value}
                 language={language}
                 height="128px"
-                onChange={(value, event) =>
-                  handleChange(value || "", fileUpload.filename, event as any)
-                }
+                onChange={(value) => setFileUpload({ ...fileUpload, value })}
                 isReadOnly={!rest.allowEditingUploadedText}
               />
             )}

--- a/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
@@ -4,16 +4,10 @@ import {
   MouseEvent as ReactMouseEvent,
   useState,
 } from "react";
-import {
-  FormGroup,
-  FileUpload,
-  Modal,
-  ModalVariant,
-  Button,
-  FileUploadProps,
-} from "@patternfly/react-core";
+import { FormGroup, Modal, ModalVariant, Button } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { FileUpload, FileUploadProps } from "./patternfly/FileUpload";
 
 type FileUploadType = {
   value: string;
@@ -59,10 +53,7 @@ export const FileUploadForm = ({
     filename,
     event
   ) => {
-    if (
-      event.nativeEvent instanceof MouseEvent &&
-      !(event.nativeEvent instanceof DragEvent)
-    ) {
+    if (event instanceof MouseEvent && !(event instanceof DragEvent)) {
       setFileUpload({ ...fileUpload, modal: true });
     } else {
       setFileUpload({
@@ -126,7 +117,7 @@ export const FileUploadForm = ({
           }
           isLoading={fileUpload.isLoading}
           dropzoneProps={{
-            accept: extension,
+            accept: { "application/text": [extension] },
           }}
         />
       )}

--- a/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
@@ -61,8 +61,7 @@ export const FileUploadForm = ({
   };
 
   const handleClear = () => {
-    setFileUpload({ ...fileUpload, value: "", filename: "" });
-    onChange("");
+    setFileUpload({ ...fileUpload, modal: true });
   };
 
   return (

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
@@ -204,6 +204,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
       onClearButtonClick={onClearButtonClick}
       onTextAreaClick={onClick}
       onTextChange={onTextChange}
+      onClick={(e) => e.stopPropagation()}
     >
       <input
         /* hidden, necessary for react-dropzone */

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
@@ -1,0 +1,216 @@
+/* eslint-disable */
+// @ts-nocheck
+import {
+  DropEvent,
+  DropzoneInputProps,
+  DropzoneOptions,
+  FileRejection,
+  useDropzone,
+} from "react-dropzone";
+import { FileUploadField, FileUploadFieldProps } from "./FileUploadField";
+import { readFile, fileReaderType } from "./fileUtils";
+import { fromEvent } from "file-selector";
+
+export interface FileUploadProps
+  extends Omit<
+    FileUploadFieldProps,
+    | "children"
+    | "onBrowseButtonClick"
+    | "onClearButtonClick"
+    | "isDragActive"
+    | "containerRef"
+  > {
+  /** Unique id for the TextArea, also used to generate ids for accessible labels. */
+  id: string;
+  /** What type of file. Determines what is is passed to `onChange` and expected by `value`
+   * (a string for 'text' and 'dataURL', or a File object otherwise. */
+  type?: "text" | "dataURL";
+  /** Value of the file's contents
+   * (string if text file, File object otherwise) */
+  value?: string | File;
+  /** Value to be shown in the read-only filename field. */
+  filename?: string;
+  /** @deprecated A callback for when the file contents change. Please instead use onFileInputChange, onTextChange, onDataChange, onClearClick individually.  */
+  onChange?: (
+    value: string | File,
+    filename: string,
+    event:
+      | React.MouseEvent<HTMLButtonElement, MouseEvent> // Clear button was clicked
+      | React.ChangeEvent<HTMLElement> // User typed in the TextArea
+      | DropEvent
+  ) => void;
+  /** Change event emitted from the hidden \<input type="file" \> field associated with the component  */
+  onFileInputChange?: (event: DropEvent, file: File) => void;
+  /** Callback for clicking on the FileUploadField text area. By default, prevents a click in the text area from opening file dialog. */
+  onClick?: (event: React.MouseEvent) => void;
+  /** Additional classes added to the FileUpload container element. */
+  className?: string;
+  /** Flag to show if the field is disabled. */
+  isDisabled?: boolean;
+  /** Flag to show if the field is read only. */
+  isReadOnly?: boolean;
+  /** Flag to show if a file is being loaded. */
+  isLoading?: boolean;
+  /** Aria-valuetext for the loading spinner */
+  spinnerAriaValueText?: string;
+  /** Flag to show if the field is required. */
+  isRequired?: boolean;
+  /** Value to indicate if the field is modified to show that validation state.
+   * If set to success, field will be modified to indicate valid state.
+   * If set to error,  field will be modified to indicate error state.
+   */
+  validated?: "success" | "error" | "default";
+  /** Aria-label for the TextArea. */
+  "aria-label"?: string;
+  /** Placeholder string to display in the empty filename field */
+  filenamePlaceholder?: string;
+  /** Aria-label for the read-only filename field */
+  filenameAriaLabel?: string;
+  /** Text for the Browse button */
+  browseButtonText?: string;
+  /** Text for the Clear button */
+  clearButtonText?: string;
+  /** Flag to hide the built-in preview of the file (where available).
+   * If true, you can use children to render an alternate preview. */
+  hideDefaultPreview?: boolean;
+  /** Flag to allow editing of a text file's contents after it is selected from disk */
+  allowEditingUploadedText?: boolean;
+  /** Additional children to render after (or instead of) the file preview. */
+  children?: React.ReactNode;
+
+  // Props available in FileUpload but not FileUploadField:
+
+  /** A callback for when a selected file starts loading */
+  onReadStarted?: (fileHandle: File) => void;
+  /** A callback for when a selected file finishes loading */
+  onReadFinished?: (fileHandle: File) => void;
+  /** A callback for when the FileReader API fails */
+  onReadFailed?: (error: DOMException, fileHandle: File) => void;
+  /** Optional extra props to customize react-dropzone. */
+  dropzoneProps?: DropzoneOptions;
+  /** Clear button was clicked */
+  onClearClick?: React.MouseEventHandler<HTMLButtonElement>;
+  /** Text area text changed */
+  onTextChange?: (text: string) => void;
+  /** On data changed - if type='text' or type='dataURL' and file was loaded it will call this method */
+  onDataChange?: (data: string) => void;
+}
+
+export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
+  id,
+  type,
+  value = type === fileReaderType.text || type === fileReaderType.dataURL
+    ? ""
+    : null,
+  filename = "",
+  children = null,
+  onChange = () => {},
+  onFileInputChange = null,
+  onReadStarted = () => {},
+  onReadFinished = () => {},
+  onReadFailed = () => {},
+  onClearClick,
+  onClick = (event) => event.preventDefault(),
+  onTextChange,
+  onDataChange,
+  dropzoneProps = {},
+  ...props
+}: FileUploadProps) => {
+  const onDropAccepted = (acceptedFiles: File[], event: DropEvent) => {
+    if (acceptedFiles.length > 0) {
+      const fileHandle = acceptedFiles[0];
+      if (event.type === "drop") {
+        onFileInputChange?.(event, fileHandle);
+      }
+      if (type === fileReaderType.text || type === fileReaderType.dataURL) {
+        onChange("", fileHandle.name, event); // Show the filename while reading
+        onReadStarted(fileHandle);
+        readFile(fileHandle, type as fileReaderType)
+          .then((data) => {
+            onReadFinished(fileHandle);
+            onChange(data as string, fileHandle.name, event);
+            onDataChange?.(data as string);
+          })
+          .catch((error: DOMException) => {
+            onReadFailed(error, fileHandle);
+            onReadFinished(fileHandle);
+            onChange("", "", event); // Clear the filename field on a failure
+            onDataChange?.("");
+          });
+      } else {
+        onChange(fileHandle, fileHandle.name, event);
+      }
+    }
+    dropzoneProps.onDropAccepted &&
+      dropzoneProps.onDropAccepted(acceptedFiles, event);
+  };
+
+  const onDropRejected = (rejectedFiles: FileRejection[], event: DropEvent) => {
+    if (rejectedFiles.length > 0) {
+      onChange("", rejectedFiles[0].file.name, event);
+    }
+    dropzoneProps.onDropRejected &&
+      dropzoneProps.onDropRejected(rejectedFiles, event);
+  };
+
+  const onClearButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    onChange("", "", event);
+    onClearClick?.(event);
+    setFileValue(null);
+  };
+
+  const { getRootProps, getInputProps, isDragActive, open, inputRef } =
+    useDropzone({
+      multiple: false,
+      ...dropzoneProps,
+      onDropAccepted,
+      onDropRejected,
+    });
+
+  const setFileValue = (filename: string) => {
+    inputRef.current.value = filename;
+  };
+
+  const oldInputProps = getInputProps();
+  const inputProps: DropzoneInputProps = {
+    ...oldInputProps,
+    onChange: async (e: React.ChangeEvent<HTMLInputElement>) => {
+      oldInputProps.onChange?.(e);
+      const files = await fromEvent(e.nativeEvent);
+      if (files.length === 1) {
+        onFileInputChange?.(e, files[0] as File);
+      }
+    },
+  };
+
+  return (
+    <FileUploadField
+      {...getRootProps({
+        ...props,
+        refKey: "containerRef",
+        onClick: (event) => event.preventDefault(),
+      })}
+      tabIndex={null} // Omit the unwanted tabIndex from react-dropzone's getRootProps
+      id={id}
+      type={type}
+      filename={filename}
+      value={value}
+      onChange={onChange}
+      isDragActive={isDragActive}
+      onBrowseButtonClick={open}
+      onClearButtonClick={onClearButtonClick}
+      onTextAreaClick={onClick}
+      onTextChange={onTextChange}
+    >
+      <input
+        /* hidden, necessary for react-dropzone */
+        {...inputProps}
+        ref={inputRef}
+      />
+      {children}
+    </FileUploadField>
+  );
+};
+FileUpload.displayName = "FileUpload";

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   DropEvent,
   DropzoneInputProps,
@@ -103,11 +102,11 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     : undefined,
   filename = "",
   children = null,
-  onChange = () => {},
+  onChange,
   onFileInputChange,
-  onReadStarted = () => {},
-  onReadFinished = () => {},
-  onReadFailed = () => {},
+  onReadStarted,
+  onReadFinished,
+  onReadFailed,
   onClearClick,
   onClick = (event) => event.preventDefault(),
   onTextChange,
@@ -122,40 +121,39 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
         onFileInputChange?.(event, fileHandle);
       }
       if (type === fileReaderType.text || type === fileReaderType.dataURL) {
-        onChange("", fileHandle.name, event); // Show the filename while reading
-        onReadStarted(fileHandle);
+        onChange?.("", fileHandle.name, event); // Show the filename while reading
+        onReadStarted?.(fileHandle);
         readFile(fileHandle, type as fileReaderType)
           .then((data) => {
-            onReadFinished(fileHandle);
-            onChange(data as string, fileHandle.name, event);
+            onReadFinished?.(fileHandle);
+            onChange?.(data as string, fileHandle.name, event);
             onDataChange?.(data as string);
           })
           .catch((error: DOMException) => {
-            onReadFailed(error, fileHandle);
-            onReadFinished(fileHandle);
-            onChange("", "", event); // Clear the filename field on a failure
+            onReadFailed?.(error, fileHandle);
+            onReadFinished?.(fileHandle);
+            onChange?.("", "", event); // Clear the filename field on a failure
             onDataChange?.("");
           });
       } else {
-        onChange(fileHandle, fileHandle.name, event);
+        onChange?.(fileHandle, fileHandle.name, event);
       }
     }
-    dropzoneProps.onDropAccepted &&
-      dropzoneProps.onDropAccepted(acceptedFiles, event);
+    dropzoneProps.onDropAccepted?.(acceptedFiles, event);
   };
 
   const onDropRejected = (rejectedFiles: FileRejection[], event: DropEvent) => {
     if (rejectedFiles.length > 0) {
-      onChange("", rejectedFiles[0].file.name, event);
+      onChange?.("", rejectedFiles[0].file.name, event);
     }
-    dropzoneProps.onDropRejected &&
-      dropzoneProps.onDropRejected(rejectedFiles, event);
+
+    dropzoneProps.onDropRejected?.(rejectedFiles, event);
   };
 
   const onClearButtonClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
-    onChange("", "", event);
+    onChange?.("", "", event);
     onClearClick?.(event);
     setFileValue("");
   };

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/FileUpload.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable */
-// @ts-nocheck
 import {
   DropEvent,
   DropzoneInputProps,
@@ -101,11 +100,11 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   type,
   value = type === fileReaderType.text || type === fileReaderType.dataURL
     ? ""
-    : null,
+    : undefined,
   filename = "",
   children = null,
   onChange = () => {},
-  onFileInputChange = null,
+  onFileInputChange,
   onReadStarted = () => {},
   onReadFinished = () => {},
   onReadFailed = () => {},
@@ -158,7 +157,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   ) => {
     onChange("", "", event);
     onClearClick?.(event);
-    setFileValue(null);
+    setFileValue("");
   };
 
   const { getRootProps, getInputProps, isDragActive, open, inputRef } =
@@ -170,6 +169,10 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     });
 
   const setFileValue = (filename: string) => {
+    if (!inputRef.current) {
+      return;
+    }
+
     inputRef.current.value = filename;
   };
 
@@ -192,7 +195,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
         refKey: "containerRef",
         onClick: (event) => event.preventDefault(),
       })}
-      tabIndex={null} // Omit the unwanted tabIndex from react-dropzone's getRootProps
+      tabIndex={undefined} // Omit the unwanted tabIndex from react-dropzone's getRootProps
       id={id}
       type={type}
       filename={filename}
@@ -213,4 +216,5 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     </FileUploadField>
   );
 };
+
 FileUpload.displayName = "FileUpload";

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/FileUploadField.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/FileUploadField.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import styles from "@patternfly/react-styles/css/components/FileUpload/file-upload";
 import { css } from "@patternfly/react-styles";
 import {
@@ -97,9 +96,9 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   type,
   value = "",
   filename = "",
-  onChange = () => {},
-  onBrowseButtonClick = () => {},
-  onClearButtonClick = () => {},
+  onChange,
+  onBrowseButtonClick,
+  onClearButtonClick,
   onTextAreaClick,
   onTextChange,
   className = "",
@@ -127,7 +126,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
     newValue: string,
     event: React.ChangeEvent<HTMLTextAreaElement>
   ) => {
-    onChange(newValue, filename, event);
+    onChange?.(newValue, filename, event);
     onTextChange?.(newValue);
   };
   return (

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/FileUploadField.tsx
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/FileUploadField.tsx
@@ -1,0 +1,202 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import styles from "@patternfly/react-styles/css/components/FileUpload/file-upload";
+import { css } from "@patternfly/react-styles";
+import {
+  Button,
+  ButtonVariant,
+  InputGroup,
+  Spinner,
+  spinnerSize,
+  TextArea,
+  TextAreResizeOrientation,
+  TextInput,
+} from "@patternfly/react-core";
+import { fileReaderType } from "./fileUtils";
+
+export interface FileUploadFieldProps
+  extends Omit<React.HTMLProps<HTMLDivElement>, "value" | "onChange"> {
+  /** Unique id for the TextArea, also used to generate ids for accessible labels */
+  id: string;
+  /** What type of file. Determines what is is expected by `value`
+   * (a string for 'text' and 'dataURL', or a File object otherwise). */
+  type?: "text" | "dataURL";
+  /** Value of the file's contents
+   * (string if text file, File object otherwise) */
+  value?: string | File;
+  /** Value to be shown in the read-only filename field. */
+  filename?: string;
+  /** A callback for when the TextArea value changes. */
+  onChange?: (
+    value: string,
+    filename: string,
+    event:
+      | React.ChangeEvent<HTMLTextAreaElement> // User typed in the TextArea
+      | React.MouseEvent<HTMLButtonElement, MouseEvent> // User clicked Clear button
+  ) => void;
+  /** Additional classes added to the FileUploadField container element. */
+  className?: string;
+  /** Flag to show if the field is disabled. */
+  isDisabled?: boolean;
+  /** Flag to show if the field is read only. */
+  isReadOnly?: boolean;
+  /** Flag to show if a file is being loaded. */
+  isLoading?: boolean;
+  /** Aria-valuetext for the loading spinner */
+  spinnerAriaValueText?: string;
+  /** Flag to show if the field is required. */
+  isRequired?: boolean;
+  /** Value to indicate if the field is modified to show that validation state.
+   * If set to success, field will be modified to indicate valid state.
+   * If set to error,  field will be modified to indicate error state.
+   */
+  validated?: "success" | "error" | "default";
+  /** Aria-label for the TextArea. */
+  "aria-label"?: string;
+  /** Placeholder string to display in the empty filename field */
+  filenamePlaceholder?: string;
+  /** Aria-label for the read-only filename field */
+  filenameAriaLabel?: string;
+  /** Text for the Browse button */
+  browseButtonText?: string;
+  /** Text for the Clear button */
+  clearButtonText?: string;
+  /** Flag to disable the Clear button */
+  isClearButtonDisabled?: boolean;
+  /** Flag to hide the built-in preview of the file (where available).
+   * If true, you can use children to render an alternate preview. */
+  hideDefaultPreview?: boolean;
+  /** Flag to allow editing of a text file's contents after it is selected from disk */
+  allowEditingUploadedText?: boolean;
+  /** Additional children to render after (or instead of) the file preview. */
+  children?: React.ReactNode;
+
+  // Props available in FileUploadField but not FileUpload:
+
+  /** A callback for when the Browse button is clicked. */
+  onBrowseButtonClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  /** A callback for when the Clear button is clicked. */
+  onClearButtonClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  /** A callback from when the text area is clicked. Can also be set via the onClick property of FileUpload. */
+  onTextAreaClick?: (
+    event: React.MouseEvent<HTMLTextAreaElement, MouseEvent>
+  ) => void;
+  /** Flag to show if a file is being dragged over the field */
+  isDragActive?: boolean;
+  /** A reference object to attach to the FileUploadField container element. */
+  containerRef?: React.Ref<HTMLDivElement>;
+  /** Text area text changed */
+  onTextChange?: (text: string) => void;
+}
+
+export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
+  id,
+  type,
+  value = "",
+  filename = "",
+  onChange = () => {},
+  onBrowseButtonClick = () => {},
+  onClearButtonClick = () => {},
+  onTextAreaClick,
+  onTextChange,
+  className = "",
+  isDisabled = false,
+  isReadOnly = false,
+  isLoading = false,
+  spinnerAriaValueText,
+  isRequired = false,
+  isDragActive = false,
+  validated = "default" as "success" | "error" | "default",
+  "aria-label": ariaLabel = "File upload",
+  filenamePlaceholder = "Drag a file here or browse to upload",
+  filenameAriaLabel = filename ? "Read only filename" : filenamePlaceholder,
+  browseButtonText = "Browse...",
+  clearButtonText = "Clear",
+  isClearButtonDisabled = !filename && !value,
+  containerRef = null as React.Ref<HTMLDivElement>,
+  allowEditingUploadedText = false,
+  hideDefaultPreview = false,
+  children = null,
+
+  ...props
+}: FileUploadFieldProps) => {
+  const onTextAreaChange = (
+    newValue: string,
+    event: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    onChange(newValue, filename, event);
+    onTextChange?.(newValue);
+  };
+  return (
+    <div
+      className={css(
+        styles.fileUpload,
+        isDragActive && styles.modifiers.dragHover,
+        isLoading && styles.modifiers.loading,
+        className
+      )}
+      ref={containerRef}
+      {...props}
+    >
+      <div className={styles.fileUploadFileSelect}>
+        <InputGroup>
+          <TextInput
+            isReadOnly // Always read-only regardless of isReadOnly prop (which is just for the TextArea)
+            isDisabled={isDisabled}
+            id={`${id}-filename`}
+            name={`${id}-filename`}
+            aria-label={filenameAriaLabel}
+            placeholder={filenamePlaceholder}
+            aria-describedby={`${id}-browse-button`}
+            value={filename}
+          />
+          <Button
+            id={`${id}-browse-button`}
+            variant={ButtonVariant.control}
+            onClick={onBrowseButtonClick}
+            isDisabled={isDisabled}
+          >
+            {browseButtonText}
+          </Button>
+          <Button
+            variant={ButtonVariant.control}
+            isDisabled={isDisabled || isClearButtonDisabled}
+            onClick={onClearButtonClick}
+          >
+            {clearButtonText}
+          </Button>
+        </InputGroup>
+      </div>
+      <div className={styles.fileUploadFileDetails}>
+        {!hideDefaultPreview && type === fileReaderType.text && (
+          <TextArea
+            readOnly={isReadOnly || (!!filename && !allowEditingUploadedText)}
+            disabled={isDisabled}
+            isRequired={isRequired}
+            resizeOrientation={TextAreResizeOrientation.vertical}
+            validated={validated}
+            id={id}
+            name={id}
+            aria-label={ariaLabel}
+            value={value as string}
+            onChange={onTextAreaChange}
+            onClick={onTextAreaClick}
+          />
+        )}
+        {isLoading && (
+          <div className={styles.fileUploadFileDetailsSpinner}>
+            <Spinner
+              size={spinnerSize.lg}
+              aria-valuetext={spinnerAriaValueText}
+            />
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+};
+FileUploadField.displayName = "FileUploadField";

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/fileUtils.ts
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/fileUtils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 export enum fileReaderType {
   text = "text",
   dataURL = "dataURL",
@@ -14,14 +13,19 @@ export enum fileReaderType {
 export function readFile(fileHandle: File, type: fileReaderType) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
+
     reader.onload = () => resolve(reader.result);
     reader.onerror = () => reject(reader.error);
-    if (type === fileReaderType.text) {
-      reader.readAsText(fileHandle);
-    } else if (type === fileReaderType.dataURL) {
-      reader.readAsDataURL(fileHandle);
-    } else {
-      reject("unknown type");
+
+    switch (type) {
+      case fileReaderType.text:
+        reader.readAsText(fileHandle);
+        break;
+      case fileReaderType.dataURL:
+        reader.readAsDataURL(fileHandle);
+        break;
+      default:
+        reject("unknown type");
     }
   });
 }

--- a/apps/admin-ui/src/components/json-file-upload/patternfly/fileUtils.ts
+++ b/apps/admin-ui/src/components/json-file-upload/patternfly/fileUtils.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+export enum fileReaderType {
+  text = "text",
+  dataURL = "dataURL",
+}
+
+/**
+ * Read a file using the FileReader API, either as a plain text string or as a DataURL string.
+ * Returns a promise which will resolve with the file contents as a string or reject with a DOMException.
+ *
+ * @param {File} fileHandle - File object to read
+ * @param {fileReaderType} type - How to read it
+ */
+export function readFile(fileHandle: File, type: fileReaderType) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    if (type === fileReaderType.text) {
+      reader.readAsText(fileHandle);
+    } else if (type === fileReaderType.dataURL) {
+      reader.readAsDataURL(fileHandle);
+    } else {
+      reject("unknown type");
+    }
+  });
+}

--- a/apps/admin-ui/vite.config.ts
+++ b/apps/admin-ui/vite.config.ts
@@ -13,16 +13,6 @@ export default defineConfig({
     mainFields: ["module"],
     dedupe: ["react", "react-dom"],
   },
-  optimizeDeps: {
-    // Enable optimization of dependencies using esbuild (see https://vitejs.dev/guide/migration.html#using-esbuild-deps-optimization-at-build-time).
-    disabled: false,
-  },
-  build: {
-    commonjsOptions: {
-      // Ensure `@rollup/plugin-commonjs` is not loaded, using esbuild instead (see https://vitejs.dev/guide/migration.html#using-esbuild-deps-optimization-at-build-time).
-      include: [],
-    },
-  },
   plugins: [react(), checker({ typescript: true })],
   test: {
     setupFiles: "vitest.setup.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "lodash-es": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-dropzone": "^14.2.2",
         "react-error-boundary": "^3.1.4",
         "react-flow-renderer": "^9.7.4",
         "react-hook-form": "^6.15.8",
@@ -3208,6 +3209,45 @@
         "react-monaco-editor": "^0.41.2"
       }
     },
+    "node_modules/@patternfly/react-code-editor/node_modules/attr-accept": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
+      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+      "dependencies": {
+        "core-js": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@patternfly/react-code-editor/node_modules/file-selector": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
+      "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@patternfly/react-code-editor/node_modules/react-dropzone": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
+      "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "dependencies": {
+        "attr-accept": "^1.1.3",
+        "file-selector": "^0.1.8",
+        "prop-types": "^15.6.2",
+        "prop-types-extra": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/@patternfly/react-core": {
       "version": "4.235.7",
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.235.7.tgz",
@@ -3224,6 +3264,45 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@patternfly/react-core/node_modules/attr-accept": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
+      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+      "dependencies": {
+        "core-js": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@patternfly/react-core/node_modules/file-selector": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
+      "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@patternfly/react-core/node_modules/react-dropzone": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
+      "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "dependencies": {
+        "attr-accept": "^1.1.3",
+        "file-selector": "^0.1.8",
+        "prop-types": "^15.6.2",
+        "prop-types-extra": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/@patternfly/react-icons": {
@@ -4688,12 +4767,9 @@
       }
     },
     "node_modules/attr-accept": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
-      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
-      "dependencies": {
-        "core-js": "^2.5.0"
-      },
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
       "engines": {
         "node": ">=4"
       }
@@ -8398,14 +8474,14 @@
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/file-selector": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
-      "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
       "dependencies": {
-        "tslib": "^2.0.1"
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/file-type": {
@@ -12155,20 +12231,19 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
-      "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.2.tgz",
+      "integrity": "sha512-5oyGN/B5rNhop2ggUnxztXBQ6q6zii+OMEftPzsxAR2hhpVWz0nAV+3Ktxo2h5bZzdcCKrpd8bfWAVsveIBM+w==",
       "dependencies": {
-        "attr-accept": "^1.1.3",
-        "file-selector": "^0.1.8",
-        "prop-types": "^15.6.2",
-        "prop-types-extra": "^1.1.0"
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10.13"
       },
       "peerDependencies": {
-        "react": ">=0.14.0"
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-error-boundary": {
@@ -17927,6 +18002,35 @@
         "@patternfly/react-styles": "^4.85.7",
         "react-dropzone": "9.0.0",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "attr-accept": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
+          "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+          "requires": {
+            "core-js": "^2.5.0"
+          }
+        },
+        "file-selector": {
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
+          "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "react-dropzone": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
+          "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+          "requires": {
+            "attr-accept": "^1.1.3",
+            "file-selector": "^0.1.8",
+            "prop-types": "^15.6.2",
+            "prop-types-extra": "^1.1.0"
+          }
+        }
       }
     },
     "@patternfly/react-core": {
@@ -17941,6 +18045,35 @@
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "attr-accept": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
+          "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
+          "requires": {
+            "core-js": "^2.5.0"
+          }
+        },
+        "file-selector": {
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
+          "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "react-dropzone": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
+          "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+          "requires": {
+            "attr-accept": "^1.1.3",
+            "file-selector": "^0.1.8",
+            "prop-types": "^15.6.2",
+            "prop-types-extra": "^1.1.0"
+          }
+        }
       }
     },
     "@patternfly/react-icons": {
@@ -18894,6 +19027,7 @@
         "progress-promise": "^0.0.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-dropzone": "^14.2.2",
         "react-error-boundary": "^3.1.4",
         "react-flow-renderer": "^9.7.4",
         "react-hook-form": "^6.15.8",
@@ -19199,12 +19333,9 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
-      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
-      "requires": {
-        "core-js": "^2.5.0"
-      }
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -21993,11 +22124,11 @@
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "file-selector": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
-      "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
       "requires": {
-        "tslib": "^2.0.1"
+        "tslib": "^2.4.0"
       }
     },
     "file-type": {
@@ -24826,14 +24957,13 @@
       }
     },
     "react-dropzone": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
-      "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.2.tgz",
+      "integrity": "sha512-5oyGN/B5rNhop2ggUnxztXBQ6q6zii+OMEftPzsxAR2hhpVWz0nAV+3Ktxo2h5bZzdcCKrpd8bfWAVsveIBM+w==",
       "requires": {
-        "attr-accept": "^1.1.3",
-        "file-selector": "^0.1.8",
-        "prop-types": "^15.6.2",
-        "prop-types-extra": "^1.1.0"
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
       }
     },
     "react-error-boundary": {


### PR DESCRIPTION
Optimize dependencies using Rollup instead of esbuild. This prevents issues where a dependency can be duplicated and create errors at runtime.