### PR TITLE
reset first param on client when start searching

### DIFF
--- a/apps/admin-ui/src/components/table-toolbar/KeycloakDataTable.tsx
+++ b/apps/admin-ui/src/components/table-toolbar/KeycloakDataTable.tsx
@@ -4,6 +4,7 @@ import {
   ReactNode,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -207,6 +208,7 @@ export function KeycloakDataTable<T>({
   const [max, setMax] = useState(10);
   const [first, setFirst] = useState(0);
   const [search, setSearch] = useState<string>("");
+  const prevSearch = useRef<string>();
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
@@ -297,8 +299,15 @@ export function KeycloakDataTable<T>({
   useFetch(
     async () => {
       setLoading(true);
+      const newSearch = prevSearch.current === "" && search !== "";
+
+      if (newSearch) {
+        setFirst(0);
+      }
+      prevSearch.current = search;
       return typeof loader === "function"
-        ? unPaginatedData || (await loader(first, max + 1, search))
+        ? unPaginatedData ||
+            (await loader(newSearch ? 0 : first, max + 1, search))
         : loader;
     },
     (data) => {

--- a/keycloak-theme/src/main/java/org/keycloak/admin/ui/rest/RoleMappingResource.java
+++ b/keycloak-theme/src/main/java/org/keycloak/admin/ui/rest/RoleMappingResource.java
@@ -24,8 +24,7 @@ public abstract class RoleMappingResource {
     public final List<ClientRole> mapping(Predicate<RoleModel> predicate, long first, long max, final String search) {
 
         return mapping(predicate).filter(clientRole -> clientRole.getClient().contains(search) || clientRole.getRole().contains(search))
-
-                .skip("".equals(search) ? first : 0).limit(max).collect(Collectors.toList());
+                .skip(first).limit(max).collect(Collectors.toList());
     }
 
     public RoleMappingResource(RealmModel realm, AdminPermissionEvaluator auth) {


### PR DESCRIPTION
fixes: #3266

## Motivation
When you start searching on the third page of a paged result you want to reset the page to 0, as there might not be 3 pages of search results.