### PR TITLE
added text component for `ProviderConfigProperty.TEXT_TYPE`

### DIFF
--- a/apps/admin-ui/src/components/dynamic/TextComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/TextComponent.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "react-i18next";
+import { useFormContext } from "react-hook-form";
+import { FormGroup } from "@patternfly/react-core";
+
+import { HelpItem } from "../help-enabler/HelpItem";
+import { KeycloakTextArea } from "../keycloak-text-area/KeycloakTextArea";
+import type { ComponentProps } from "./components";
+import { convertToName } from "./DynamicComponents";
+
+export const TextComponent = ({
+  name,
+  label,
+  helpText,
+  defaultValue,
+  isDisabled = false,
+}: ComponentProps) => {
+  const { t } = useTranslation("dynamic");
+  const { register } = useFormContext();
+
+  return (
+    <FormGroup
+      label={t(label!)}
+      labelIcon={
+        <HelpItem helpText={t(helpText!)} fieldLabelId={`dynamic:${label}`} />
+      }
+      fieldId={name!}
+    >
+      <KeycloakTextArea
+        id={name!}
+        data-testid={name}
+        isDisabled={isDisabled}
+        ref={register()}
+        type="text"
+        name={convertToName(name!)}
+        defaultValue={defaultValue?.toString()}
+      />
+    </FormGroup>
+  );
+};

--- a/apps/admin-ui/src/components/dynamic/TextComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/TextComponent.tsx
@@ -30,7 +30,6 @@ export const TextComponent = ({
         data-testid={name}
         isDisabled={isDisabled}
         ref={register()}
-        type="text"
         name={convertToName(name!)}
         defaultValue={defaultValue?.toString()}
       />

--- a/apps/admin-ui/src/components/dynamic/components.ts
+++ b/apps/admin-ui/src/components/dynamic/components.ts
@@ -2,6 +2,7 @@ import type { FunctionComponent } from "react";
 
 import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
 import { StringComponent } from "./StringComponent";
+import { TextComponent } from "./TextComponent";
 import { BooleanComponent } from "./BooleanComponent";
 import { ListComponent } from "./ListComponent";
 import { RoleComponent } from "./RoleComponent";
@@ -20,6 +21,7 @@ export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
 
 const ComponentTypes = [
   "String",
+  "Text",
   "boolean",
   "List",
   "Role",
@@ -39,6 +41,7 @@ export const COMPONENTS: {
   [index in Components]: FunctionComponent<ComponentProps>;
 } = {
   String: StringComponent,
+  Text: TextComponent,
   boolean: BooleanComponent,
   List: ListComponent,
   Role: RoleComponent,


### PR DESCRIPTION
- fix opening the execution config modal
- added component for type TEXT

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
