### PR TITLE
Allow triggering Cypress workflow by dispatch

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes we need to run the tests on release branches manually, so let's make it possible to manually run this workflow.