### PR TITLE
Always pass in `--host` for Vite dev server

### DIFF
--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext js,jsx,mjs,ts,tsx",


### PR DESCRIPTION
Since recent changes in Vite the dev server is no longer available to Cypress tests during development unles the `--host` flag is passed to it.