### PR TITLE
Add Wireit to automatically build Keycloak JS

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Run build task
-        run: npm run build --workspace=keycloak-js --workspace=admin-ui
+        run: npm run build --workspace=admin-ui
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Keycloak JS
-        run: npm run build --workspace=keycloak-js
-
       - name: Cache setup
         uses: actions/cache@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ assets
 
 # Keycloak server
 server
+
+# Wireit
+.wireit

--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -1,16 +1,48 @@
 {
   "name": "admin-ui",
   "scripts": {
-    "dev": "vite --host",
-    "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint . --ext js,jsx,mjs,ts,tsx",
-    "test": "vitest",
+    "dev": "wireit",
+    "build": "wireit",
+    "preview": "wireit",
+    "lint": "wireit",
+    "test": "wireit",
     "cy:open": "cypress open --e2e --browser chrome",
     "cy:run": "cypress run --browser chrome",
     "cy:check-types": "tsc --project cypress/tsconfig.json",
     "server:start": "./scripts/start-server.mjs",
     "server:import-client": "./scripts/import-client.mjs"
+  },
+  "wireit": {
+    "dev": {
+      "command": "vite --host",
+      "dependencies": [
+        "../../libs/keycloak-js:build"
+      ]
+    },
+    "preview": {
+      "command": "vite preview",
+      "dependencies": [
+        "../../libs/keycloak-js:build"
+      ]
+    },
+    "build": {
+      "command": "vite build",
+      "dependencies": [
+        "../../libs/keycloak-js:build"
+      ]
+    },
+    "lint": {
+      "command": "eslint . --ext js,jsx,mjs,ts,tsx",
+      "dependencies": [
+        "../../libs/keycloak-js:build"
+      ]
+    },
+    "test": {
+      "command": "vitest",
+      "dependencies": [
+        "../../libs/keycloak-js:build"
+      ]
+    }
   },
   "dependencies": {
     "@keycloak/keycloak-admin-client": "^19.0.1",

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -237,7 +237,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>run build --workspace=keycloak-js --workspace=admin-ui</arguments>
+                            <arguments>run build --workspace=admin-ui</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/libs/keycloak-js/package.json
+++ b/libs/keycloak-js/package.json
@@ -9,8 +9,15 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup --config --configPlugin typescript",
+    "build": "wireit",
     "prepublishOnly": "npm run build"
+  },
+  "wireit": {
+    "build": {
+      "command": "rollup --config --configPlugin typescript",
+      "files": ["src/**", "rollup.config.ts", "tsconfig.json"],
+      "output": ["dist/**", "!dist/*.d.ts"]
+    }
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
-        "typescript": "^4.8.3"
+        "typescript": "^4.8.3",
+        "wireit": "^0.7.1"
       }
     },
     "apps/admin-ui": {
@@ -10578,6 +10579,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -12321,6 +12328,17 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -13026,6 +13044,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -15880,6 +15907,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wireit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
+      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
+      },
+      "bin": {
+        "wireit": "bin/wireit.js"
+      },
+      "engines": {
+        "node": ">=14.14.0"
       }
     },
     "node_modules/word-wrap": {
@@ -24013,6 +24059,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -25360,6 +25412,17 @@
         "warning": "^4.0.0"
       }
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -25904,6 +25967,12 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true
     },
     "reusify": {
@@ -28101,6 +28170,19 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "wireit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.7.1.tgz",
+      "integrity": "sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "typescript": "^4.8.3"
+    "typescript": "^4.8.3",
+    "wireit": "^0.7.1"
   },
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix"


### PR DESCRIPTION
Adds [Wireit](https://github.com/google/wireit) to automatically build Keycloak JS whenever needed. For example, when building the Admin UI you want to make sure the latest version of Keycloak JS has been built in the workspace.

The configuration set up here for Wireit allows us to also cache the Keycloak JS build so it will only run once unless changes are made to Keycloak JS itself.