### PR TITLE
Prevent Dependabot from updating react-router

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     ignore:
       - dependency-name: react-hook-form
         update-types: ["version-update:semver-major"]
+      - dependency-name: react-router
+        update-types: ["version-update:semver-major"]
       - dependency-name: react-router-dom
         update-types: ["version-update:semver-major"]
       - dependency-name: use-react-router-breadcrumbs


### PR DESCRIPTION
We can't upgrade React Router just yet, so let's hold back Dependabot from updating major versions.