### PR TITLE
Add default value true to closeNotification

### DIFF
--- a/apps/admin-ui/cypress/e2e/events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/events_test.spec.ts
@@ -66,6 +66,9 @@ describe("Events tests", () => {
         .enableSaveEventsSwitch()
         .save()
         .clearUserEvents();
+
+      cy.wait(5000);
+
       sidebarPage.goToEvents();
       eventsPage.goToUserEventsTab();
       userEventsTab.assertNoSearchResultsExist(true);
@@ -98,6 +101,8 @@ describe("Events tests", () => {
         .goToUserEventsSettingsSubTab()
         .disableSaveEventsSwitch()
         .save();
+
+      cy.wait(5000);
 
       masthead.signOut();
       loginPage.logIn();
@@ -271,6 +276,9 @@ describe("Events tests", () => {
         .disableSaveEvents()
         .save()
         .clearAdminEvents();
+
+      cy.wait(5000);
+
       sidebarPage.goToEvents();
       eventsPage.goToAdminEventsTab();
       adminEventsTab.assertNoSearchResultsExist(true);

--- a/apps/admin-ui/cypress/e2e/realm_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_test.spec.ts
@@ -61,8 +61,7 @@ describe("Realm tests", () => {
 
     createRealmPage.fillRealmName(testRealmName).createRealm();
 
-    masthead.checkNotificationMessage("Realm created");
-    masthead.closeAllAlertMessages();
+    masthead.checkNotificationMessage("Realm created successfully");
   });
 
   it("should create Test Disabled realm", () => {
@@ -71,11 +70,10 @@ describe("Realm tests", () => {
     createRealmPage.fillRealmName("Test Disabled").createRealm();
     createRealmPage.disableRealm();
 
-    masthead.checkNotificationMessage("Realm created");
+    masthead.checkNotificationMessage("Realm created successfully");
   });
 
   it("Should cancel deleting Test Disabled realm", () => {
-    masthead.closeAllAlertMessages();
     sidebarPage.goToRealm("Test Disabled").goToRealmSettings();
     realmSettings.clickActionMenu();
     cy.findByText("Delete").click();
@@ -100,14 +98,14 @@ describe("Realm tests", () => {
     const fetchUrl = "/admin/realms?briefRepresentation=true";
     cy.intercept(fetchUrl).as("fetch");
 
-    masthead.checkNotificationMessage("Realm created");
+    masthead.checkNotificationMessage("Realm created successfully");
 
     cy.wait(["@fetch"]);
 
     sidebarPage.goToCreateRealm();
     createRealmPage.fillRealmName(editedRealmName).createRealm();
 
-    masthead.checkNotificationMessage("Realm created");
+    masthead.checkNotificationMessage("Realm created successfully");
 
     cy.wait(["@fetch"]);
 

--- a/apps/admin-ui/cypress/e2e/sessions_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/sessions_test.spec.ts
@@ -67,7 +67,11 @@ describe("Sessions test", () => {
 
     it("Push when URI not configured", () => {
       sessionsPage.pushRevocation();
-      commonPage.masthead().checkNotificationMessage("No push sent");
+      commonPage
+        .masthead()
+        .checkNotificationMessage(
+          "No push sent. No admin URI configured or no registered cluster nodes available"
+        );
     });
   });
 

--- a/apps/admin-ui/cypress/e2e/user_fed_kerberos_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/user_fed_kerberos_test.spec.ts
@@ -195,9 +195,7 @@ describe("User Fed Kerberos tests", () => {
 
     masthead.checkNotificationMessage(savedSuccessMessage);
     sidebarPage.goToUserFederation();
-    masthead.checkNotificationMessage(savedSuccessMessage);
 
-    sidebarPage.goToUserFederation();
     expect(cy.contains("Disabled").should("exist"));
   });
 

--- a/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/user_fed_ldap_test.spec.ts
@@ -87,7 +87,6 @@ const savedSuccessMessage = "User federation provider successfully saved";
 const deletedSuccessMessage = "The user federation provider has been deleted.";
 const deleteModalTitle = "Delete user federation provider?";
 const disableModalTitle = "Disable user federation provider?";
-const nonWritableFailMessage = "User federation provider could not be saved:";
 const validatePasswordPolicyFailMessage =
   "User federation provider could not be saved: Validate Password Policy is applicable only with WRITABLE edit mode";
 const userImportingDisabledFailMessage =
@@ -141,7 +140,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.save(provider);
     masthead.checkNotificationMessage(createdSuccessMessage);
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should fail updating advanced settings", () => {
@@ -150,9 +148,8 @@ describe("User Federation LDAP tests", () => {
     providersPage.toggleSwitch(providersPage.validatePwPolicySwitch);
     providersPage.toggleSwitch(providersPage.trustEmailSwitch);
     providersPage.save(provider);
-    masthead.checkNotificationMessage(nonWritableFailMessage);
+    masthead.checkNotificationMessage(validatePasswordPolicyFailMessage);
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should update advanced settings", () => {
@@ -175,7 +172,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.verifyToggle(providersPage.ldapv3PwSwitch, "on");
     providersPage.verifyToggle(providersPage.validatePwPolicySwitch, "on");
     providersPage.verifyToggle(providersPage.trustEmailSwitch, "on");
-    masthead.closeAllAlertMessages();
   });
 
   it("Should set cache policy to evict_daily", () => {
@@ -191,7 +187,6 @@ describe("User Federation LDAP tests", () => {
 
     expect(cy.contains(dailyPolicy).should("exist"));
     expect(cy.contains(defaultPolicy).should("not.exist"));
-    masthead.closeAllAlertMessages();
   });
 
   it("Should set cache policy to default", () => {
@@ -205,7 +200,6 @@ describe("User Federation LDAP tests", () => {
 
     expect(cy.contains(defaultPolicy).should("exist"));
     expect(cy.contains(dailyPolicy).should("not.exist"));
-    masthead.closeAllAlertMessages();
   });
 
   it("Should set cache policy to evict_weekly", () => {
@@ -222,7 +216,6 @@ describe("User Federation LDAP tests", () => {
 
     expect(cy.contains(weeklyPolicy).should("exist"));
     expect(cy.contains(defaultPolicy).should("not.exist"));
-    masthead.closeAllAlertMessages();
   });
 
   it("Update connection and authentication settings and save", () => {
@@ -259,7 +252,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.verifyToggle(providersPage.enableStartTls, "on");
     providersPage.verifyToggle(providersPage.connectionPooling, "on");
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should fail connection and authentication tests", () => {
@@ -272,7 +264,6 @@ describe("User Federation LDAP tests", () => {
     masthead.checkNotificationMessage(ldapTestFailMsg);
 
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should make changes and pass connection and authentication tests", () => {
@@ -298,7 +289,6 @@ describe("User Federation LDAP tests", () => {
     masthead.checkNotificationMessage(ldapTestSuccessMsg);
 
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should update Kerberos integration settings and save", () => {
@@ -338,7 +328,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.verifyToggle(providersPage.useKerberosForPwAuth, "on");
 
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should update Synchronization settings and save", () => {
@@ -377,7 +366,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.verifyToggle(providersPage.periodicUsersSync, "on");
     providersPage.verifyToggle(providersPage.importUsers, "on");
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should update LDAP searching and updating settings and save", () => {
@@ -470,7 +458,6 @@ describe("User Federation LDAP tests", () => {
       providersPage.ldapEditModeInput,
       editModeUnsynced
     );
-    masthead.closeAllAlertMessages();
   });
 
   it("Should update display name", () => {
@@ -484,7 +471,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.clickExistingCard(updatedLdapName);
 
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should update existing LDAP provider and cancel", () => {
@@ -517,7 +503,6 @@ describe("User Federation LDAP tests", () => {
 
     expect(cy.contains(lifespanPolicy).should("exist"));
     expect(cy.contains(weeklyPolicy).should("not.exist"));
-    masthead.closeAllAlertMessages();
   });
 
   it("Should set cache policy to no_cache", () => {
@@ -541,7 +526,6 @@ describe("User Federation LDAP tests", () => {
     masthead.checkNotificationMessage(savedSuccessMessage);
     sidebarPage.goToUserFederation();
     expect(cy.contains("Disabled").should("exist"));
-    masthead.closeAllAlertMessages();
   });
 
   it("Should enable a previously-disabled LDAP provider", () => {
@@ -551,7 +535,6 @@ describe("User Federation LDAP tests", () => {
     masthead.checkNotificationMessage(savedSuccessMessage);
     sidebarPage.goToUserFederation();
     expect(cy.contains("Enabled").should("exist"));
-    masthead.closeAllAlertMessages();
   });
 
   it("Should create new LDAP provider using New Provider dropdown", () => {
@@ -576,7 +559,6 @@ describe("User Federation LDAP tests", () => {
     providersPage.save(provider);
     masthead.checkNotificationMessage(createdSuccessMessage);
     sidebarPage.goToUserFederation();
-    masthead.closeAllAlertMessages();
   });
 
   it("Should delete LDAP provider from card view using card menu", () => {

--- a/apps/admin-ui/cypress/e2e/users_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/users_test.spec.ts
@@ -275,7 +275,6 @@ describe("User creation", () => {
             true
           );
         }
-        masthead.closeAllAlertMessages();
       });
     });
 
@@ -335,7 +334,6 @@ describe("User creation", () => {
             true
           );
         }
-        masthead.closeAllAlertMessages();
       });
     });
   });

--- a/apps/admin-ui/cypress/support/pages/CommonElements.ts
+++ b/apps/admin-ui/cypress/support/pages/CommonElements.ts
@@ -31,8 +31,8 @@ export default class CommonElements {
     return this;
   }
 
-  clickSecondaryBtn(buttonName: string) {
-    cy.get(this.secondaryBtn).contains(buttonName).click();
+  clickSecondaryBtn(buttonName: string, force = false) {
+    cy.get(this.secondaryBtn).contains(buttonName).click({ force: force });
     return this;
   }
 

--- a/apps/admin-ui/cypress/support/pages/admin_console/Masthead.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/Masthead.ts
@@ -49,11 +49,13 @@ export default class Masthead extends CommonElements {
     cy.get("#manage-account").click();
   }
 
-  checkNotificationMessage(message: string, closeNotification: boolean = true) {
+  checkNotificationMessage(message: string, closeNotification = true) {
     cy.get(this.alertMessage).should("contain.text", message);
 
     if (closeNotification) {
-      cy.get(`button[title="${message}"]`).last().click({ force: true });
+      cy.get(`button[title="` + message.replaceAll('"', '\\"') + `"]`)
+        .last()
+        .click({ force: true });
     }
     return this;
   }

--- a/apps/admin-ui/cypress/support/pages/admin_console/Masthead.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/Masthead.ts
@@ -49,7 +49,7 @@ export default class Masthead extends CommonElements {
     cy.get("#manage-account").click();
   }
 
-  checkNotificationMessage(message: string, closeNotification?: boolean) {
+  checkNotificationMessage(message: string, closeNotification: boolean = true) {
     cy.get(this.alertMessage).should("contain.text", message);
 
     if (closeNotification) {

--- a/apps/admin-ui/cypress/support/pages/admin_console/components/PageObject.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/components/PageObject.ts
@@ -340,4 +340,9 @@ export default class PageObject {
     cy.get(this.breadcrumbItem).contains(itemName).click();
     return this;
   }
+
+  protected waitForPageLoad() {
+    cy.get('[role="progressbar"]').should("not.exist");
+    return this;
+  }
 }

--- a/apps/admin-ui/cypress/support/pages/admin_console/manage/clients/client_details/DedicatedScopesMappersTab.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/manage/clients/client_details/DedicatedScopesMappersTab.ts
@@ -30,7 +30,7 @@ export default class DedicatedScopesMappersTab extends CommonPage {
   addPredefinedMapper() {
     this.emptyState()
       .checkIfExists(true)
-      .clickSecondaryBtn(mapperTypeEmptyState.AddPredefinedMapper);
+      .clickSecondaryBtn(mapperTypeEmptyState.AddPredefinedMapper, true);
     return this;
   }
 

--- a/apps/admin-ui/cypress/support/pages/admin_console/manage/realm_settings/tabs/realmsettings_events_subtabs/UserEventsSettingsTab.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/manage/realm_settings/tabs/realmsettings_events_subtabs/UserEventsSettingsTab.ts
@@ -21,6 +21,7 @@ export default class UserEventsSettingsTab extends PageObject {
   disableSaveEventsSwitch() {
     cy.get(this.saveEventsSwitch).parent().click();
     super.assertSwitchStateOn(cy.get(this.saveEventsSwitch));
+    this.waitForPageLoad();
     modal.checkModalTitle("Unsave events?");
     modal.confirmModal();
     super.assertSwitchStateOff(cy.get(this.saveEventsSwitch));


### PR DESCRIPTION
Set default value of closeNotification to true, so it closes notifications on all the checks, to avoid having too many notifications due to the bug that they sometimes don't disappear