### PR TITLE
Fix path to keycloak theme readme

### DIFF
--- a/apps/admin-ui/README.md
+++ b/apps/admin-ui/README.md
@@ -58,7 +58,7 @@ You can now start making changes to the source code, and they will be reflected 
 
 ## Building as a Keycloak theme
 
-If you want to build the application using Maven and produce a JAR that can be installed directly into Keycloak, check out the [Keycloak theme documentation](./keycloak-theme/README.md).
+If you want to build the application using Maven and produce a JAR that can be installed directly into Keycloak, check out the [Keycloak theme documentation](../../keycloak-theme/README.md).
 
 ## Linting
 


### PR DESCRIPTION
## Motivation
I was reading through the Keycloak UI documentation and I was getting a 404 on the link to the theme readme.

## Brief Description
What was done in this PR? Updated path to theme readme to reference correct file.
Why it was done? Users were getting a 404 trying to navigate to doc on theming.

## Verification Steps
1. Go to the Preview of this PR or https://github.com/PinPinIre/keycloak-ui/tree/patch-1/apps/admin-ui
2. Search for the #building-as-a-keycloak-theme section
3. Click on the `Keycloak theme documentation` link

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
N/A