### PR TITLE
Add possibility to import custom styles by extending the theme

### DIFF
--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -362,7 +362,7 @@
                         </replacement>
                         <replacement>
                             <token><![CDATA[</head>]]></token>
-							<value xml:space="preserve">
+                            <value xml:space="preserve">
 <![CDATA[
     <#if properties.styles?has_content>
 	    <#list properties.styles?split(' ') as style>

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -360,6 +360,19 @@
 ]]>
 </value>
                         </replacement>
+						<replacement>
+                            <token><![CDATA[</head>]]></token>
+							<value xml:space="preserve">
+<![CDATA[
+    <#if properties.styles?has_content>
+	    <#list properties.styles?split(' ') as style>
+	    <link href="${resourceUrl}/${style}" rel="stylesheet"/>
+	    </#list>
+    </#if>
+  </head>
+]]>	
+</value>
+                        </replacement>
                     </replacements>
 
                 </configuration>

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -365,9 +365,9 @@
                             <value xml:space="preserve">
 <![CDATA[
     <#if properties.styles?has_content>
-	    <#list properties.styles?split(' ') as style>
-	    <link href="${resourceUrl}/${style}" rel="stylesheet"/>
-	    </#list>
+      <#list properties.styles?split(' ') as style>
+      <link href="${resourceUrl}/${style}" rel="stylesheet"/>
+      </#list>
     </#if>
   </head>
 ]]>	

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -360,7 +360,7 @@
 ]]>
 </value>
                         </replacement>
-						<replacement>
+                        <replacement>
                             <token><![CDATA[</head>]]></token>
 							<value xml:space="preserve">
 <![CDATA[


### PR DESCRIPTION
## Motivation
resolves #3364 

This PR adds the possibility to import custom styles when extending from the theme. The style import would would similar to the way it works in the account theme.

## Brief Description
When copying over the index.html to the index.ftl file the necessary code for importing custom styles is inserted via replacing the end tag of the head.  

## Verification Steps
1. Build and package the theme with `mvn package`.
2. Check the index.ftl file in the target folder.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
None
