### PR TITLE
Adjusted initialization of admin-client-ui with different urls in hostname and hostname-admin

### DIFF
--- a/apps/admin-ui/src/context/auth/AdminClient.tsx
+++ b/apps/admin-ui/src/context/auth/AdminClient.tsx
@@ -85,7 +85,7 @@ export async function initAdminClient() {
   const adminClient = new KeycloakAdminClient();
 
   adminClient.setConfig({ realmName: environment.loginRealm });
-  adminClient.baseUrl = keycloak.authServerUrl ?? environment.authServerUrl;
+  adminClient.baseUrl = environment.authUrl;
   adminClient.registerTokenProvider({
     async getAccessToken() {
       try {


### PR DESCRIPTION
## Motivation
Fix https://github.com/keycloak/keycloak-ui/issues/3374 

## Brief Description
Use the "correct" URLs for initialization.

## Verification Steps
Start keycloak with --hostname and a different --hostname-admin.
Try to access the admin-konsole.
Either CORS Issues from calling --hostname based URLs from within the --hostname-admin or the calls go to --hostname without error.
The --hostname-admin must be used for all ajax calls from within the admin-console.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
Work in progress. Missing tests, but want to verify the direction this is heading.
