### PR TITLE
only load realms when dropdown is opened

### DIFF
--- a/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
+++ b/apps/admin-ui/src/components/realm-selector/RealmSelector.tsx
@@ -7,6 +7,7 @@ import {
   DropdownItem,
   DropdownToggle,
   Label,
+  Spinner,
   Split,
   SplitItem,
 } from "@patternfly/react-core";
@@ -27,7 +28,7 @@ import "./realm-selector.css";
 
 export const RealmSelector = () => {
   const { realm } = useRealm();
-  const { realms } = useRealms();
+  const { realms, refresh } = useRealms();
   const { whoAmI } = useWhoAmI();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -83,16 +84,23 @@ export const RealmSelector = () => {
     navigate(toDashboard({ realm }));
   };
 
-  const dropdownItems = realms.map((r) => (
-    <DropdownItem
-      key={`realm-dropdown-item-${r.realm}`}
-      onClick={() => {
-        selectRealm(r.realm!);
-      }}
-    >
-      <RealmText value={r.realm!} />
-    </DropdownItem>
-  ));
+  const dropdownItems =
+    realms.length !== 0
+      ? realms.map((r) => (
+          <DropdownItem
+            key={`realm-dropdown-item-${r.realm}`}
+            onClick={() => {
+              selectRealm(r.realm!);
+            }}
+          >
+            <RealmText value={r.realm!} />
+          </DropdownItem>
+        ))
+      : [
+          <DropdownItem key="load">
+            Loading <Spinner size="sm" />
+          </DropdownItem>,
+        ];
 
   const addRealmComponent = (
     <Fragment key="Add Realm">
@@ -162,6 +170,7 @@ export const RealmSelector = () => {
               {toUpperCase(realm)}
             </DropdownToggle>
           }
+          onFocus={refresh}
           dropdownItems={[...dropdownItems, addRealmComponent]}
         />
       )}

--- a/apps/admin-ui/src/context/RealmsContext.tsx
+++ b/apps/admin-ui/src/context/RealmsContext.tsx
@@ -1,6 +1,12 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import { sortBy } from "lodash-es";
-import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import {
+  FunctionComponent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import axios from "axios";
 
 import { RecentUsed } from "../components/realm-selector/recent-used";
@@ -24,6 +30,7 @@ export const RealmsProvider: FunctionComponent = ({ children }) => {
   const { keycloak, adminClient } = useAdminClient();
   const [realms, setRealms] = useState<RealmRepresentation[]>([]);
   const recentUsed = useMemo(() => new RecentUsed(), []);
+  const firstRender = useRef(0);
 
   function updateRealms(realms: RealmRepresentation[]) {
     setRealms(sortBy(realms, "realm"));
@@ -32,6 +39,10 @@ export const RealmsProvider: FunctionComponent = ({ children }) => {
 
   useFetch(
     async () => {
+      if (firstRender.current === 0) {
+        firstRender.current = 1;
+        return [];
+      }
       try {
         return await adminClient.realms.find({ briefRepresentation: true });
       } catch (error) {


### PR DESCRIPTION
this will not totally fix the issue but make the console at least usable

fixes: #3381

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
