### PR TITLE
Add a `<base>` element for relative URLs

### DIFF
--- a/apps/admin-ui/index.html
+++ b/apps/admin-ui/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <base href="./" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Web site to manage keycloak" />
     <title>Keycloak Administration Console</title>

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -340,11 +340,11 @@
                     <regex>false</regex>
                     <replacements>
                         <replacement>
-                            <token>src="</token>
+                            <token>src="./</token>
                             <value>src="${resourceUrl}/</value>
                         </replacement>
                         <replacement>
-                            <token>href="</token>
+                            <token>href="./</token>
                             <value>href="${resourceUrl}/</value>
                         </replacement>
                         <replacement>


### PR DESCRIPTION
Add a `<base>` element for improved security around relative URLs. Closes #3442.