### PR TITLE
Added group id to assigned-roles data table key to reload when navigating groups

### DIFF
--- a/apps/admin-ui/src/components/role-mapping/RoleMapping.tsx
+++ b/apps/admin-ui/src/components/role-mapping/RoleMapping.tsx
@@ -195,7 +195,7 @@ export const RoleMapping = ({
       <DeleteConfirm />
       <KeycloakDataTable
         data-testid="assigned-roles"
-        key={key}
+        key={`${id}${key}`}
         loader={loader}
         canSelectAll
         onSelect={(rows) => setSelected(rows)}


### PR DESCRIPTION
Added group id to assigned-roles data table key to reload when navigating groups

## Motivation
Closes #3413

## Brief Description
Added group id to assigned-roles data table to reload role mappins when navigating the groups

## Verification Steps
1. Go to a group and assign roles from a client
2. Go to a different page
3. Go back to the group and see that role mappins show the client roles assigned

## Checklist:
- [X] Code has been tested locally by PR requester
