### PR TITLE
Use Keycloak config endpoint in production

### DIFF
--- a/apps/admin-ui/src/context/auth/AdminClient.tsx
+++ b/apps/admin-ui/src/context/auth/AdminClient.tsx
@@ -71,14 +71,21 @@ export function useFetch<T>(
   }, deps);
 }
 
-export async function initAdminClient() {
-  const keycloak = new Keycloak({
+function getKeycloakConfig() {
+  if (environment.isRunningAsTheme) {
+    return environment.consoleBaseUrl + "config";
+  }
+
+  return {
     url: environment.authServerUrl,
     realm: environment.loginRealm,
-    clientId: environment.isRunningAsTheme
-      ? "security-admin-console"
-      : "security-admin-console-v2",
-  });
+    clientId: "security-admin-console-v2",
+  };
+}
+
+export async function initAdminClient() {
+  const config = getKeycloakConfig();
+  const keycloak = new Keycloak(config);
 
   await keycloak.init({ onLoad: "check-sso", pkceMethod: "S256" });
 


### PR DESCRIPTION
Changes the config for Keycloak JS in when running in production so it uses [this endpoint](https://github.com/keycloak/keycloak/blob/fb24c86a3bf4dcfd661e11288686afe8a88f10ef/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java#L180-L189) instead. This is the [same behavior](https://github.com/keycloak/keycloak/blob/fb24c86a3bf4dcfd661e11288686afe8a88f10ef/themes/src/main/resources/theme/base/admin/resources/js/app.js#L14) as the old Admin Console.

This might address issues where the Admin UI uses an incorrect URL to make requests when Keycloak is running behind a reverse proxy that splits the OpenID Connect endpoints from the rest of Keycloak.