### PR TITLE
Allow user and admin attribute permissions to be independantly set

### DIFF
--- a/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributePermission.tsx
+++ b/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributePermission.tsx
@@ -28,11 +28,10 @@ const Permissions = ({ name }: { name: string }) => {
                   const option = "user";
                   const changedValue = value.includes(option)
                     ? value.filter((item: string) => item !== option)
-                    : [option];
+                    : [...value, option];
 
                   onChange(changedValue);
                 }}
-                isDisabled={value.includes("admin")}
               />
             </GridItem>
             <GridItem lg={8} sm={6}>
@@ -46,7 +45,7 @@ const Permissions = ({ name }: { name: string }) => {
                   const option = "admin";
                   const changedValue = value.includes(option)
                     ? value.filter((item: string) => item !== option)
-                    : ["user", option];
+                    : [...value, option];
 
                   onChange(changedValue);
                 }}


### PR DESCRIPTION
## Motivation
When using the experimental feature declarative user profile it was not possible to allow only the admin to view/edit an attribute. When admin was selected, user was always included.

## Brief Description
Changed update handling of attribute permission checkboxes.

## Verification Steps
1. Enable declarative user profile feature
2. Set "User Profile Enabled" to "on"
3. Go "User Profile" and edit any attribute
4. Select "admin" (user should no longer be selected automatically)

## Checklist:

- [X] Code has been tested locally by PR requester
- [NA] User-visible strings are using the react-i18next framework (useTranslation)
- [NA] Help has been implemented
- [NA] axe report has been run and resulting a11y issues have been resolved
- [NA] Unit tests have been created/updated
