### PR TITLE
Use specific container for Cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -81,6 +81,7 @@ jobs:
     needs: [build-keycloak, install-nightly]
     if: always() && ( needs.build-keycloak.result == 'success' || needs.install-nightly.result == 'success' )
     runs-on: ubuntu-latest
+    container: cypress/browsers:node16.17.0-chrome106
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Our test suite currently fails on errors during parallelization, this seems to be caused by a mismatch in browser versions between worker jobs. Pinning the browser version by using a Cypress image might help resolve this issue.