### PR TITLE
Stop running Cypress tests in parallel

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -81,10 +81,6 @@ jobs:
     needs: [build-keycloak, install-nightly]
     if: always() && ( needs.build-keycloak.result == 'success' || needs.install-nightly.result == 'success' )
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4, 5]
     steps:
       - name: Check out Admin UI
         uses: actions/checkout@v3
@@ -117,7 +113,6 @@ jobs:
         with:
           install: false
           record: true
-          parallel: true
           browser: chrome
           wait-on: http://localhost:8080
           working-directory: apps/admin-ui

--- a/apps/admin-ui/cypress.config.mjs
+++ b/apps/admin-ui/cypress.config.mjs
@@ -17,10 +17,6 @@ export default defineConfig({
   numTestsKeptInMemory: 30,
   videoUploadOnPasses: false,
 
-  retries: {
-    runMode: 3,
-  },
-
   e2e: {
     setupNodeEvents(on) {
       on(


### PR DESCRIPTION
Allows the Cypress tests to run again by disabling parallelization. This is currently broken due to https://github.com/cypress-io/github-action/issues/602.