### PR TITLE
Fix typo in dashboard.json

### DIFF
--- a/apps/admin-ui/public/resources/en/dashboard.json
+++ b/apps/admin-ui/public/resources/en/dashboard.json
@@ -1,7 +1,7 @@
 {
   "realmName": "{{name}} realm",
   "welcome": "Welcome to",
-  "introduction": "If you want to leave this page and mange this realm, please click the corresponding menu items in the left navigation bar.",
+  "introduction": "If you want to leave this page and manage this realm, please click the corresponding menu items in the left navigation bar.",
   "serverInfo": "Server info",
   "version": "Version",
   "product": "Product",


### PR DESCRIPTION
## Motivation
Simple fix for typo - was always jumping to my eyes when selecting a realm  
English: `mange` instead of `manage`

## Brief Description
Only a very brief typo fix

## Verification Steps
Open a realm (other than "_master_") and see the text shown in the main screen

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
None
