### PR TITLE
Run Cypress tests in parallel again

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,6 +14,9 @@ on:
       keycloakBranch:
         description: The branch to check out for the Keycloak repo (e.g. main).
         required: false
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-keycloak:
     if: ${{ github.event_name != 'schedule' }}
@@ -81,6 +84,10 @@ jobs:
     needs: [build-keycloak, install-nightly]
     if: always() && ( needs.build-keycloak.result == 'success' || needs.install-nightly.result == 'success' )
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5]
     steps:
       - name: Check out Admin UI
         uses: actions/checkout@v3
@@ -113,6 +120,7 @@ jobs:
         with:
           install: false
           record: true
+          parallel: true
           browser: chrome
           wait-on: http://localhost:8080
           working-directory: apps/admin-ui


### PR DESCRIPTION
Reverts some of the changes #3485, allowing the Cypress tests to run in parallel again.