### PR TITLE
Re-enable test retries for Cypress

### DIFF
--- a/apps/admin-ui/cypress.config.mjs
+++ b/apps/admin-ui/cypress.config.mjs
@@ -17,6 +17,10 @@ export default defineConfig({
   numTestsKeptInMemory: 30,
   videoUploadOnPasses: false,
 
+  retries: {
+    runMode: 3,
+  },
+
   e2e: {
     setupNodeEvents(on) {
       on(


### PR DESCRIPTION
This should improve the amount of tests passing.