### PR TITLE
Remove optional param from new permission route

### DIFF
--- a/apps/admin-ui/src/clients/routes/NewPermission.ts
+++ b/apps/admin-ui/src/clients/routes/NewPermission.ts
@@ -21,7 +21,7 @@ export const NewPermissionRoute: RouteDef = {
 
 export const NewPermissionWithSelectedIdRoute: RouteDef = {
   ...NewPermissionRoute,
-  path: "/:realm/clients/:id/authorization/permission/new/:permissionType/:selectedId?",
+  path: "/:realm/clients/:id/authorization/permission/new/:permissionType/:selectedId",
 };
 
 export const toNewPermission = (params: NewPermissionParams): Partial<Path> => {


### PR DESCRIPTION
Removes an optional parameter from the new permission route. Optional parameters are not supported by React Router v6, so this is causing errors at runtime.