### PR TITLE
Run CI jobs for the Account UI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        command: [lint, test, build, "cy:check-types"]
+        include:
+          - workspace: admin-ui
+            command: lint
+          - workspace: admin-ui
+            command: test
+          - workspace: admin-ui
+            command: build
+          - workspace: admin-ui
+            command: cy:check-types
+          - workspace: account-ui
+            command: lint
+          - workspace: account-ui
+            command: build
     steps:
       - name: Restore setup
         uses: actions/cache@v3
@@ -48,4 +60,4 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Run ${{ matrix.command }} task
-        run: npm run ${{ matrix.command }} --workspace=admin-ui
+        run: npm run ${{ matrix.command }} --workspace=${{ matrix.workspace }}

--- a/apps/account-ui/vite.config.ts
+++ b/apps/account-ui/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   server: {
     port: 8080,
   },
+  build: {
+    target: "ES2022",
+  },
   resolve: {
     // Resolve the 'module' entrypoint at all times (not the default due to Node.js compatibility issues).
     mainFields: ["module"],

--- a/apps/admin-ui/vite.config.ts
+++ b/apps/admin-ui/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   server: {
     port: 8080,
   },
+  build: {
+    target: "ES2022",
+  },
   resolve: {
     // Resolve the 'module' entrypoint at all times (not the default due to Node.js compatibility issues).
     mainFields: ["module"],


### PR DESCRIPTION
Allows the CI to run the linting and build tasks for the Account UI to ensure no regressions are introduced by accident.