### PR TITLE
Added view password - issue-1775

### DIFF
--- a/apps/admin-ui/src/realm-settings/EmailTab.tsx
+++ b/apps/admin-ui/src/realm-settings/EmailTab.tsx
@@ -21,6 +21,7 @@ import { useRealm } from "../context/realm-context/RealmContext";
 import { useWhoAmI } from "../context/whoami/WhoAmI";
 import { emailRegexPattern } from "../util";
 import { AddUserEmailModal } from "./AddUserEmailModal";
+import { PasswordInput } from "../components/password-input/PasswordInput";
 import "./realm-settings-section.css";
 
 type RealmSettingsEmailTabProps = {
@@ -372,16 +373,15 @@ export const RealmSettingsEmailTab = ({
                     />
                   }
                 >
-                  <KeycloakTextInput
-                    type="password"
+                  <PasswordInput
                     id="kc-password"
                     data-testid="password-input"
                     name="smtpServer.password"
-                    ref={register({ required: true })}
-                    placeholder="Login password"
+                    aria-label={t("password")}
                     validated={
                       errors.smtpServer?.password ? "error" : "default"
                     }
+                    ref={register({ required: true })}
                   />
                 </FormGroup>
               </>


### PR DESCRIPTION
## Motivation
Closes https://github.com/keycloak/keycloak-ui/issues/1775

Note: I also searched the codebase for all the places where we have implemented passwords, and they all seem to use the PasswordInput component.

## Verification Steps
1. Go to `Realm settings > Email` and enable `Authentication`
2. Verify that it's now possible to view the password.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
