### PR TITLE
Use official terser plugin for Rollup

### DIFF
--- a/libs/keycloak-js/package.json
+++ b/libs/keycloak-js/package.json
@@ -37,10 +37,10 @@
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-inject": "^5.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-terser": "^0.1.0",
     "@rollup/plugin-typescript": "^9.0.2",
     "es6-promise": "^4.2.8",
-    "rollup": "^3.2.3",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup": "^3.2.3"
   },
   "dependencies": {
     "base64-js": "^1.5.1",

--- a/libs/keycloak-js/rollup.config.ts
+++ b/libs/keycloak-js/rollup.config.ts
@@ -1,10 +1,10 @@
 import commonjs from "@rollup/plugin-commonjs";
 import inject from "@rollup/plugin-inject";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
+import terser from '@rollup/plugin-terser';
 import path from "node:path";
 import type { OutputOptions, RollupOptions } from "rollup";
 import { defineConfig } from "rollup";
-import { terser } from "rollup-plugin-terser";
 
 interface DefineOptionsArgs {
   file: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,10 +365,10 @@
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-inject": "^5.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-terser": "^0.1.0",
         "@rollup/plugin-typescript": "^9.0.2",
         "es6-promise": "^4.2.8",
-        "rollup": "^3.2.3",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup": "^3.2.3"
       }
     },
     "libs/keycloak-js/node_modules/rollup": {
@@ -3681,6 +3681,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz",
+      "integrity": "sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==",
+      "dev": true,
+      "dependencies": {
+        "terser": "^5.15.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x || ^3.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -10058,19 +10078,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/js-sdsl": {
       "version": "4.1.4",
       "dev": true,
@@ -12602,20 +12609,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -13599,9 +13592,10 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.15.0",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -17452,6 +17446,15 @@
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz",
+      "integrity": "sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==",
+      "dev": true,
+      "requires": {
+        "terser": "^5.15.1"
       }
     },
     "@rollup/plugin-typescript": {
@@ -21823,15 +21826,6 @@
         "picomatch": "^2.2.3"
       }
     },
-    "jest-worker": {
-      "version": "26.6.2",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      }
-    },
     "js-sdsl": {
       "version": "4.1.4",
       "dev": true
@@ -21973,12 +21967,12 @@
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-inject": "^5.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-terser": "*",
         "@rollup/plugin-typescript": "^9.0.2",
         "base64-js": "^1.5.1",
         "es6-promise": "^4.2.8",
         "js-sha256": "^0.9.0",
-        "rollup": "^3.2.3",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup": "^3.2.3"
       },
       "dependencies": {
         "rollup": {
@@ -23522,16 +23516,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "7.0.2",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -24204,7 +24188,9 @@
       }
     },
     "terser": {
-      "version": "5.15.0",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",


### PR DESCRIPTION
Replaces [`rollup-plugin-terser`](https://www.npmjs.com/package/rollup-plugin-terser) with the official [`@rollup/plugin-terser`](https://github.com/rollup/plugins/tree/master/packages/terser). Since `rollup-plugin-terser` is not compatible with Rollup 3 it is causing issues on a clean NPM install.