### PR TITLE
Use correct namespace for i18n types

### DIFF
--- a/apps/account-ui/src/react-i18next.d.ts
+++ b/apps/account-ui/src/react-i18next.d.ts
@@ -1,8 +1,9 @@
-import "react-i18next";
+// https://www.i18next.com/overview/typescript
+import "i18next";
 
 import translation from "../public/locales/en/translation.json";
 
-declare module "react-i18next" {
+declare module "i18next" {
   interface CustomTypeOptions {
     defaultNS: "translation";
     resources: {


### PR DESCRIPTION
Changes the type definitions for `i18next` to the correct module namespace. This was changed in the recent major version, but this migration was not yet applied.