### PR TITLE
Use `react-hook-form` v7 for session revocation

### DIFF
--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -76,6 +76,7 @@
     "react-error-boundary": "^3.1.4",
     "react-flow-renderer": "^9.7.4",
     "react-hook-form": "^6.15.8",
+    "react-hook-form-v7": "npm:react-hook-form@^7.35.1",
     "react-i18next": "^12.0.0",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4",

--- a/apps/admin-ui/src/sessions/RevocationModal.tsx
+++ b/apps/admin-ui/src/sessions/RevocationModal.tsx
@@ -11,7 +11,7 @@ import {
   ValidatedOptions,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
+import { useForm } from "react-hook-form-v7";
 
 import { emailRegexPattern } from "../util";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
@@ -201,7 +201,6 @@ export const RevocationModal = ({
         >
           <KeycloakTextInput
             data-testid="not-before-input"
-            ref={register({ required: true, pattern: emailRegexPattern })}
             autoFocus
             isReadOnly
             value={
@@ -211,7 +210,10 @@ export const RevocationModal = ({
             }
             type="text"
             id="not-before"
-            name="notBefore"
+            {...register("notBefore", {
+              required: true,
+              pattern: emailRegexPattern,
+            })}
             validated={
               errors.email ? ValidatedOptions.error : ValidatedOptions.default
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
         "react-error-boundary": "^3.1.4",
         "react-flow-renderer": "^9.7.4",
         "react-hook-form": "^6.15.8",
+        "react-hook-form-v7": "npm:react-hook-form@^7.35.1",
         "react-i18next": "^12.0.0",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
@@ -12137,6 +12138,22 @@
         "react": "^16.8.0 || ^17"
       }
     },
+    "node_modules/react-hook-form-v7": {
+      "name": "react-hook-form",
+      "version": "7.39.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.39.3.tgz",
+      "integrity": "sha512-H/vwk1vBf+TiXuyW6+hWz+zCujiDO6NqHlN5sPE/a+NGKKGK95XTM65DZz3NmEgs2M20Wka+g4uv4VD367wDBA==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
@@ -18762,6 +18779,7 @@
         "react-error-boundary": "^3.1.4",
         "react-flow-renderer": "^9.7.4",
         "react-hook-form": "^6.15.8",
+        "react-hook-form-v7": "npm:react-hook-form@^7.35.1",
         "react-i18next": "^12.0.0",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
@@ -23613,6 +23631,12 @@
     },
     "react-hook-form": {
       "version": "6.15.8",
+      "requires": {}
+    },
+    "react-hook-form-v7": {
+      "version": "npm:react-hook-form@7.39.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.39.3.tgz",
+      "integrity": "sha512-H/vwk1vBf+TiXuyW6+hWz+zCujiDO6NqHlN5sPE/a+NGKKGK95XTM65DZz3NmEgs2M20Wka+g4uv4VD367wDBA==",
       "requires": {}
     },
     "react-is": {


### PR DESCRIPTION
Adds an alias to v7  of `react-hook-form` to the package and refactors the revocation modal to use it.