### PR TITLE
Wait for network requests to finish in events test

### DIFF
--- a/apps/admin-ui/cypress/e2e/events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/events_test.spec.ts
@@ -277,8 +277,6 @@ describe("Events tests", () => {
         .save()
         .clearAdminEvents();
 
-      cy.wait(5000);
-
       sidebarPage.goToEvents();
       eventsPage.goToAdminEventsTab();
       adminEventsTab.assertNoSearchResultsExist(true);

--- a/apps/admin-ui/cypress/support/pages/admin_console/manage/realm_settings/tabs/realmsettings_events_subtabs/AdminEventsSettingsTab.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/manage/realm_settings/tabs/realmsettings_events_subtabs/AdminEventsSettingsTab.ts
@@ -13,7 +13,9 @@ export default class AdminEventsSettingsTab extends PageObject {
   clearAdminEvents() {
     cy.get(this.clearAdminEventsBtn).click();
     modal.checkModalTitle("Clear events");
+    cy.intercept("/admin/realms/master/admin-events").as("clearEvents");
     modal.confirmModal();
+    cy.wait("@clearEvents");
     masthead.checkNotificationMessage("The admin events have been cleared");
     return this;
   }
@@ -35,7 +37,9 @@ export default class AdminEventsSettingsTab extends PageObject {
   }
 
   save() {
+    cy.intercept("/admin/realms/master").as("saveRealm");
     cy.get(this.saveBtn).click();
+    cy.wait("@saveRealm");
     return this;
   }
 }


### PR DESCRIPTION
Add interceptors for API calls related to the Admin Events, then wait for them to finish before continuing. This should resolve intermittently failing tests.

Closes #3653