### PR TITLE
Add `server:import-client` script to Wireit configuration

### DIFF
--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -11,7 +11,7 @@
     "cy:check-types": "wireit",
     "cy:ldap-server": "ldap-server-mock --conf=./cypress/fixtures/ldap/server.json --database=./cypress/fixtures/ldap/users.json",
     "server:start": "./scripts/start-server.mjs",
-    "server:import-client": "./scripts/import-client.mjs"
+    "server:import-client": "wireit"
   },
   "wireit": {
     "dev": {
@@ -51,6 +51,12 @@
     },
     "cy:check-types": {
       "command": "tsc --project cypress/tsconfig.json",
+      "dependencies": [
+        "../../libs/keycloak-admin-client:build"
+      ]
+    },
+    "server:import-client": {
+      "command": "./scripts/import-client.mjs",
       "dependencies": [
         "../../libs/keycloak-admin-client:build"
       ]


### PR DESCRIPTION
Adds the `server:import-client` script to Wireit configuration, as it depends on the Admin Client. This ensures the Admin Client is built before running the script, preventing import errors/ 