### PR TITLE
Use `Object.hasOwn()` instead of `Object.prototype.hasOwnProperty()`

### DIFF
--- a/apps/admin-ui/src/util.ts
+++ b/apps/admin-ui/src/util.ts
@@ -76,10 +76,7 @@ const isAttributeArray = (value: any) => {
   }
 
   return value.some(
-    (e) =>
-      // TODO: Use Object.hasOwn() when Firefox ESR supports it.
-      Object.prototype.hasOwnProperty.call(e, "key") &&
-      Object.prototype.hasOwnProperty.call(e, "value")
+    (e) => Object.hasOwn(e, "key") && Object.hasOwn(e, "value")
   );
 };
 


### PR DESCRIPTION
This feature is now also supported by the latest ESR release of Firefox. Closes #2883.