### PR TITLE
Allow view IDP with view-identity-providers role.

### DIFF
--- a/apps/admin-ui/src/identity-providers/routes/IdentityProvider.ts
+++ b/apps/admin-ui/src/identity-providers/routes/IdentityProvider.ts
@@ -16,7 +16,7 @@ export const IdentityProviderRoute: RouteDef = {
   path: "/:realm/identity-providers/:providerId/:alias/:tab",
   component: lazy(() => import("../add/DetailSettings")),
   breadcrumb: (t) => t("identity-providers:providerDetails"),
-  access: "manage-identity-providers",
+  access: "view-identity-providers",
 };
 
 export const toIdentityProvider = (


### PR DESCRIPTION
## Motivation
Fixes #3725 

## Verification Steps
See steps in #3725 

## Additional Notes
User is required to have at least `view-identity-providers` and `query-clients` roles.
