### PR TITLE
Hide permissions tabs when ADMIN_FINE_GRAINED_AUTHZ is disabled.

### DIFF
--- a/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -31,6 +31,7 @@ import { GroupRoleMapping } from "./GroupRoleMapping";
 import helpUrls from "../help-urls";
 import { PermissionsTab } from "../components/permission-tab/PermissionTab";
 import { useAccess } from "../context/access/Access";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { GroupTree } from "./components/GroupTree";
 import { DeleteGroup } from "./components/DeleteGroup";
 import useToggle from "../utils/useToggle";
@@ -41,6 +42,8 @@ import "./GroupsSection.css";
 export default function GroupsSection() {
   const { t } = useTranslation("groups");
   const [activeTab, setActiveTab] = useState(0);
+
+  const { profileInfo } = useServerInfo();
 
   const { adminClient } = useAdminClient();
   const { subGroups, setSubGroups, currentGroup } = useSubGroups();
@@ -57,11 +60,9 @@ export default function GroupsSection() {
   const refresh = () => setKey(key + 1);
 
   const { hasAccess } = useAccess();
-  const canViewPermissions = hasAccess(
-    "manage-authorization",
-    "manage-users",
-    "manage-clients"
-  );
+  const canViewPermissions =
+    !profileInfo?.disabledFeatures?.includes("ADMIN_FINE_GRAINED_AUTHZ") &&
+    hasAccess("manage-authorization", "manage-users", "manage-clients");
   const canManageGroup =
     hasAccess("manage-users") || currentGroup()?.access?.manage;
   const canManageRoles = hasAccess("manage-users");

--- a/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -28,6 +28,7 @@ import { AdvancedSettings } from "./AdvancedSettings";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useRealm } from "../../context/realm-context/RealmContext";
+import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { KeycloakTabs } from "../../components/keycloak-tabs/KeycloakTabs";
 import { ExtendedNonDiscoverySettings } from "./ExtendedNonDiscoverySettings";
 import { DiscoverySettings } from "./DiscoverySettings";
@@ -120,6 +121,7 @@ export default function DetailSettings() {
   const navigate = useNavigate();
   const { realm } = useRealm();
   const [key, setKey] = useState(0);
+  const { profileInfo } = useServerInfo();
   const refresh = () => setKey(key + 1);
 
   const MapperLink = ({ name, mapperId }: IdPWithMapperAttributes) => (
@@ -444,14 +446,18 @@ export default function DetailSettings() {
               ]}
             />
           </Tab>
-          <Tab
-            id="permissions"
-            data-testid="permissionsTab"
-            eventKey="permissions"
-            title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
-          >
-            <PermissionsTab id={alias} type="identityProviders" />
-          </Tab>
+          {!profileInfo?.disabledFeatures?.includes(
+            "ADMIN_FINE_GRAINED_AUTHZ"
+          ) && (
+            <Tab
+              id="permissions"
+              data-testid="permissionsTab"
+              eventKey="permissions"
+              title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
+            >
+              <PermissionsTab id={alias} type="identityProviders" />
+            </Tab>
+          )}
         </KeycloakTabs>
       </PageSection>
     </FormProvider>

--- a/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
+++ b/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
@@ -15,6 +15,7 @@ import { omit } from "lodash-es";
 
 import { useAlerts } from "../components/alert/Alerts";
 import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import {
   AttributesForm,
@@ -60,6 +61,8 @@ export default function RealmRoleTabs() {
   const { realm: realmName } = useRealm();
 
   const [key, setKey] = useState(0);
+
+  const { profileInfo } = useServerInfo();
 
   const refresh = () => {
     setKey(key + 1);
@@ -415,12 +418,16 @@ export default function RealmRoleTabs() {
                 <UsersInRoleTab data-cy="users-in-role-tab" />
               </Tab>
             )}
-            <Tab
-              eventKey="permissions"
-              title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
-            >
-              <PermissionsTab id={role.id} type="roles" />
-            </Tab>
+            {!profileInfo?.disabledFeatures?.includes(
+              "ADMIN_FINE_GRAINED_AUTHZ"
+            ) && (
+              <Tab
+                eventKey="permissions"
+                title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
+              >
+                <PermissionsTab id={role.id} type="roles" />
+              </Tab>
+            )}
           </KeycloakTabs>
         )}
       </PageSection>

--- a/apps/admin-ui/src/user/UsersSection.tsx
+++ b/apps/admin-ui/src/user/UsersSection.tsx
@@ -34,6 +34,7 @@ import type { IRowData } from "@patternfly/react-table";
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
@@ -69,6 +70,7 @@ export default function UsersSection() {
   const [realm, setRealm] = useState<RealmRepresentation | undefined>();
   const [kebabOpen, setKebabOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<UserRepresentation[]>([]);
+  const { profileInfo } = useServerInfo();
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
@@ -411,14 +413,18 @@ export default function UsersSection() {
               ]}
             />
           </Tab>
-          <Tab
-            id="permissions"
-            data-testid="permissionsTab"
-            title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
-            {...route("permissions")}
-          >
-            <PermissionsTab type="users" />
-          </Tab>
+          {!profileInfo?.disabledFeatures?.includes(
+            "ADMIN_FINE_GRAINED_AUTHZ"
+          ) && (
+            <Tab
+              id="permissions"
+              data-testid="permissionsTab"
+              title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
+              {...route("permissions")}
+            >
+              <PermissionsTab type="users" />
+            </Tab>
+          )}
         </RoutableTabs>
       </PageSection>
     </>


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-ui/issues/3741

## Brief Description
Permissions tabs should not be shown if `ADMIN_FINE_GRAINED_AUTHZ` is disabled.

## Verification Steps
1. Start Keycloak with `--features=preview` flag.
2. Permissions tab should be visible in Client Details, Group Details, Realm Role Details, User main screen, and IDP Details.
3. Start Keycloak without `--features=preview` flag.
4. Permissions tabs should no longer be visible.
