### PR TITLE
Use `react-hook-form` v7 for OTP policy form

### DIFF
--- a/libs/keycloak-admin-client/src/defs/realmRepresentation.ts
+++ b/libs/keycloak-admin-client/src/defs/realmRepresentation.ts
@@ -85,6 +85,7 @@ export default interface RealmRepresentation {
   otpPolicyPeriod?: number;
   otpPolicyType?: string;
   otpSupportedApplications?: string[];
+  otpPolicyCodeReusable?: boolean;
   passwordPolicy?: string;
   permanentLockout?: boolean;
   // ProtocolMapperRepresentation


### PR DESCRIPTION
Refactors the OTP policy form to use v7 of `react-hook-form`, and cleans up the code a little.