### PR TITLE
Upload Keycloak server logs when running Cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5]
+        container: [1, 2, 3, 4, 5]
     steps:
       - name: Check out Admin UI
         uses: actions/checkout@v3
@@ -117,7 +117,7 @@ jobs:
       - name: Start Keycloak Server
         run: |
           tar xfvz keycloak-999-SNAPSHOT.tar.gz
-          keycloak-999-SNAPSHOT/bin/kc.sh start-dev --features=admin2,admin-fine-grained-authz,declarative-user-profile &
+          keycloak-999-SNAPSHOT/bin/kc.sh start-dev --features=admin2,admin-fine-grained-authz,declarative-user-profile &> ~/server.log &
         env:
           KEYCLOAK_ADMIN: admin
           KEYCLOAK_ADMIN_PASSWORD: admin
@@ -136,3 +136,9 @@ jobs:
           CYPRESS_KEYCLOAK_SERVER: http://localhost:8080
           CYPRESS_RECORD_KEY: b8f1d15e-eab8-4ee7-8e44-c6d7cd8fc0eb
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload server logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: server-log-${{ matrix.container }}
+          path: ~/server.log


### PR DESCRIPTION
Upload the Keycloak server logs when running the Cypress tests. This will allow us to diagnose issues when API calls fail unexpectedly.