### PR TITLE
Use `string` type for dates for `findEvents` method

### DIFF
--- a/libs/keycloak-admin-client/src/resources/realms.ts
+++ b/libs/keycloak-admin-client/src/resources/realms.ts
@@ -126,8 +126,8 @@ export class Realms extends Resource {
     {
       realm: string;
       client?: string;
-      dateFrom?: Date;
-      dateTo?: Date;
+      dateFrom?: string;
+      dateTo?: string;
       first?: number;
       ipAddress?: string;
       max?: number;


### PR DESCRIPTION
t looks like the types here are incorrect. The Date object is invalid to query Keycloak api and throws an error: Invalid value for 'Date(From)', expected format is yyyy-MM-dd" when used.

