### PR TITLE
Don't use a default value in `BooleanComponent`

### DIFF
--- a/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
@@ -142,32 +142,38 @@ describe("Realm settings events tab tests", () => {
 
     cy.findByTestId("option-aes-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_aes-generated");
+    realmSettingsPage.toggleSwitch("active", false);
+    realmSettingsPage.toggleSwitch("enabled", false);
     realmSettingsPage.addProvider();
 
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-ecdsa-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_ecdsa-generated");
-    realmSettingsPage.toggleSwitch("active", false);
+    realmSettingsPage.toggleSwitch("enabled", false);
     realmSettingsPage.addProvider();
 
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-hmac-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_hmac-generated");
-    realmSettingsPage.toggleSwitch("enabled", false);
+    realmSettingsPage.toggleSwitch("active", false);
     realmSettingsPage.addProvider();
 
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-rsa-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_rsa-generated");
+    realmSettingsPage.toggleSwitch("active", false);
+    realmSettingsPage.toggleSwitch("enabled", false);
     realmSettingsPage.addProvider();
 
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-rsa-enc-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_rsa-enc-generated");
+    realmSettingsPage.toggleSwitch("active", false);
+    realmSettingsPage.toggleSwitch("enabled", false);
     realmSettingsPage.addProvider();
   });
 

--- a/apps/admin-ui/src/components/dynamic/BooleanComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/BooleanComponent.tsx
@@ -10,7 +10,6 @@ export const BooleanComponent = ({
   name,
   label,
   helpText,
-  defaultValue,
   isDisabled = false,
 }: ComponentProps) => {
   const { t } = useTranslation("dynamic");
@@ -28,7 +27,7 @@ export const BooleanComponent = ({
       <Controller
         name={convertToName(name!)}
         data-testid={name}
-        defaultValue={defaultValue || false}
+        defaultValue={false}
         control={control}
         render={({ onChange, value }) => (
           <Switch


### PR DESCRIPTION
apparently when the property is not there it means `false`

fixes: #3819

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
