### PR TITLE
Upload server logs even when tests fail

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: Run Cypress
         uses: cypress-io/github-action@v4
+        continue-on-error: true
         with:
           install: false
           record: true


### PR DESCRIPTION
This will ensure the logs of the Keycloak server are uploaded, even if the tests job has failed.