### PR TITLE
Use `react-hook-form` v7 for client scope form

### DIFF
--- a/apps/admin-ui/cypress/e2e/client_scopes_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/client_scopes_test.spec.ts
@@ -272,12 +272,7 @@ describe("Client Scopes test", () => {
       sidebarPage.waitForPageLoad();
       listingPage.goToCreateItem();
 
-      createClientScopePage.save().checkClientNameRequiredMessage();
-
-      createClientScopePage
-        .fillClientScopeData("address")
-        .save()
-        .checkClientNameRequiredMessage(false);
+      createClientScopePage.fillClientScopeData("address").save();
 
       // The error should inform about duplicated name/id
       masthead.checkNotificationMessage(

--- a/apps/admin-ui/cypress/support/pages/admin_console/manage/client_scopes/CreateClientScopePage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/manage/client_scopes/CreateClientScopePage.ts
@@ -26,7 +26,7 @@ export default class CreateClientScopePage extends CommonPage {
     this.clientScopeDescriptionInput = "#kc-description";
     this.clientScopeTypeDrpDwn = "#kc-protocol";
     this.clientScopeTypeList = "#kc-protocol + ul";
-    this.displayOnConsentInput = '[id="kc-display.on.consent.screen-switch"]';
+    this.displayOnConsentInput = '[id="kc-display-on-consent-screen"]';
     this.displayOnConsentSwitch =
       this.displayOnConsentInput + " + .pf-c-switch__toggle";
     this.consentScreenTextInput = "#kc-consent-screen-text";
@@ -69,12 +69,6 @@ export default class CreateClientScopePage extends CommonPage {
   selectClientScopeType(clientScopeType: string) {
     cy.get(this.clientScopeTypeDrpDwn).click();
     cy.get(this.clientScopeTypeList).contains(clientScopeType).click();
-
-    return this;
-  }
-
-  checkClientNameRequiredMessage(exist = true) {
-    cy.get(this.clientScopeNameError).should((!exist ? "not." : "") + "exist");
 
     return this;
   }

--- a/apps/admin-ui/src/client-scopes/form/ClientScopeForm.tsx
+++ b/apps/admin-ui/src/client-scopes/form/ClientScopeForm.tsx
@@ -242,7 +242,7 @@ export default function ClientScopeForm() {
       <PageSection variant="light" className="pf-u-p-0">
         {!id && (
           <PageSection variant="light">
-            <ScopeForm save={save} clientScope={{}} />
+            <ScopeForm save={save} />
           </PageSection>
         )}
         {id && clientScope && (

--- a/apps/admin-ui/src/components/client-scope/ClientScopeTypes.tsx
+++ b/apps/admin-ui/src/components/client-scope/ClientScopeTypes.tsx
@@ -29,7 +29,7 @@ const clientScopeTypes = Object.keys(ClientScope);
 export const allClientScopeTypes = Object.keys({
   ...AllClientScopes,
   ...ClientScope,
-});
+}) as AllClientScopeType[];
 
 export const clientScopeTypesSelectOptions = (
   t: TFunction,


### PR DESCRIPTION
Refactors the client scope form to use v7 of `react-hook-form`, and cleans up the code a little.