### PR TITLE
Only cancel CI jobs on pushes for PRs

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,9 @@ on:
         description: The branch to check out for the Keycloak repo (e.g. main).
         required: false
 concurrency:
-  group: ${{ github.ref }}
+  # Only cancel jobs for new commits on PRs, and always do a complete run on other branches (e.g. `main`).
+  # See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   build-keycloak:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+concurrency:
+  # Only cancel jobs for new commits on PRs, and always do a complete run on other branches (e.g. `main`).
+  # See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 env:
   NODE_VERSION: 18
 jobs:


### PR DESCRIPTION
Sets up the concurrency for CI so that jobs on branches like `main` will always run to completion (not getting cancelled by new merges). This change will still cancel previous jobs when pushing new commits on PRs, cutting down our GitHub Actions & Cypress Dashboard runtime.