### PR TITLE
Add worflow name to concurrency group

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,7 @@ on:
 concurrency:
   # Only cancel jobs for new commits on PRs, and always do a complete run on other branches (e.g. `main`).
   # See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
-  group: ${{ github.head_ref || github.run_id }}
+  group: cypress-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   build-keycloak:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 concurrency:
   # Only cancel jobs for new commits on PRs, and always do a complete run on other branches (e.g. `main`).
   # See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
-  group: ${{ github.head_ref || github.run_id }}
+  group: main-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
   NODE_VERSION: 18


### PR DESCRIPTION
Adds the name of the workflows (`main`, and `cypress`) to the concurrency group. This should prevent these jobs from cancelling each other out.