### PR TITLE
Add repo info for GH CLI calls

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Admin UI
+      - name: Check out repository
         uses: actions/checkout@v3
         with:
           path: admin-ui-repo
@@ -91,7 +91,7 @@ jobs:
       matrix:
         container: [1, 2, 3, 4, 5]
     steps:
-      - name: Check out Admin UI
+      - name: Check out repository
         uses: actions/checkout@v3
 
       - name: Set up Node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Admin UI
+      - name: Check out repository
         uses: actions/checkout@v3
 
       - name: Set up Node
@@ -88,3 +88,5 @@ jobs:
         run: gh pr merge --auto --squash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}


### PR DESCRIPTION
Should fix the issue where the Dependabot auto-merge fails to identify the repository.