### PR TITLE
Replaced word `mapping(s)` with word `role(s)` - issue 985

### DIFF
--- a/apps/admin-ui/cypress/e2e/client_scopes_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/client_scopes_test.spec.ts
@@ -343,7 +343,7 @@ describe("Client Scopes test", () => {
       masthead.checkNotificationMessage("Role mapping updated");
       scopeTab.checkRoles([role]);
       scopeTab.hideInheritedRoles().selectRow(role).unAssign();
-      modalUtils.checkModalTitle("Remove mapping?").confirmModal();
+      modalUtils.checkModalTitle("Remove role?").confirmModal();
       scopeTab.checkRoles([]);
     });
   });

--- a/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -634,7 +634,7 @@ describe("Clients test", () => {
       rolesTab.goToAssociatedRolesTab();
       commonPage.tableUtils().selectRowItemAction("create-realm", "Unassign");
       commonPage.sidebar().waitForPageLoad();
-      commonPage.modalUtils().checkModalTitle("Remove mapping?").confirmModal();
+      commonPage.modalUtils().checkModalTitle("Remove role?").confirmModal();
       commonPage.sidebar().waitForPageLoad();
 
       commonPage
@@ -643,7 +643,7 @@ describe("Clients test", () => {
 
       commonPage.tableUtils().selectRowItemAction("manage-consent", "Unassign");
       commonPage.sidebar().waitForPageLoad();
-      commonPage.modalUtils().checkModalTitle("Remove mapping?").confirmModal();
+      commonPage.modalUtils().checkModalTitle("Remove role?").confirmModal();
     });
 
     it("Should delete associated role from search bar test", () => {
@@ -662,7 +662,7 @@ describe("Clients test", () => {
       associatedRolesPage.removeAssociatedRoles();
 
       commonPage.sidebar().waitForPageLoad();
-      commonPage.modalUtils().checkModalTitle("Remove mapping?").confirmModal();
+      commonPage.modalUtils().checkModalTitle("Remove role?").confirmModal();
       commonPage.sidebar().waitForPageLoad();
 
       commonPage
@@ -880,7 +880,7 @@ describe("Clients test", () => {
       serviceAccountTab.selectRow("create-realm").unAssign();
 
       commonPage.sidebar().waitForPageLoad();
-      commonPage.modalUtils().checkModalTitle("Remove mapping?").confirmModal();
+      commonPage.modalUtils().checkModalTitle("Remove role?").confirmModal();
       commonPage
         .masthead()
         .checkNotificationMessage("Scope mapping successfully removed");

--- a/apps/admin-ui/cypress/e2e/realm_roles_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_roles_test.spec.ts
@@ -153,7 +153,7 @@ describe("Realm roles test", () => {
     rolesTab.goToAssociatedRolesTab();
     listingPage.removeItem("create-realm");
     sidebarPage.waitForPageLoad();
-    modalUtils.checkModalTitle("Remove mapping?").confirmModal();
+    modalUtils.checkModalTitle("Remove role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
     masthead.checkNotificationMessage(
@@ -172,7 +172,7 @@ describe("Realm roles test", () => {
     associatedRolesPage.removeAssociatedRoles();
 
     sidebarPage.waitForPageLoad();
-    modalUtils.checkModalTitle("Remove mapping?").confirmModal();
+    modalUtils.checkModalTitle("Remove role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
     masthead.checkNotificationMessage(
@@ -203,7 +203,7 @@ describe("Realm roles test", () => {
     // delete associated roles from list
     listingPage.removeItem("create-realm");
     sidebarPage.waitForPageLoad();
-    modalUtils.checkModalTitle("Remove mapping?").confirmModal();
+    modalUtils.checkModalTitle("Remove role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
     masthead.checkNotificationMessage(
@@ -212,7 +212,7 @@ describe("Realm roles test", () => {
     );
     listingPage.removeItem("offline_access");
     sidebarPage.waitForPageLoad();
-    modalUtils.checkModalTitle("Remove mapping?").confirmModal();
+    modalUtils.checkModalTitle("Remove role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
     masthead.checkNotificationMessage(

--- a/apps/admin-ui/cypress/e2e/realm_user_registration.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_user_registration.spec.ts
@@ -48,8 +48,8 @@ describe("Realm settings - User registration tab", () => {
     listingPage.markItemRow(role).removeMarkedItems("Unassign");
     sidebarPage.waitForPageLoad();
     modalUtils
-      .checkModalTitle("Remove mapping?")
-      .checkModalMessage("Are you sure you want to remove this mapping?")
+      .checkModalTitle("Remove role?")
+      .checkModalMessage("Are you sure you want to remove this role?")
       .checkConfirmButtonText("Remove")
       .confirmModal();
     masthead.checkNotificationMessage("Scope mapping successfully removed");

--- a/apps/admin-ui/cypress/support/pages/admin_console/manage/groups/group_details/GroupDetailPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin_console/manage/groups/group_details/GroupDetailPage.ts
@@ -173,7 +173,7 @@ export default class GroupDetailPage extends GroupPage {
 
   deleteRole() {
     modalUtils
-      .checkModalTitle("Remove mapping?")
+      .checkModalTitle("Remove role?")
       .checkConfirmButtonText("Remove")
       .confirmModal();
   }

--- a/apps/admin-ui/public/resources/en/clients.json
+++ b/apps/admin-ui/public/resources/en/clients.json
@@ -99,9 +99,9 @@
   "password": "Password",
   "oneTimePassword": "One-Time Password",
   "kerberos": "Kerberos",
-  "removeMappingTitle": "Remove mapping?",
-  "removeMappingConfirm_one": "Are you sure you want to remove this mapping?",
-  "removeMappingConfirm_other": "Are you sure you want to remove {{count}} mappings",
+  "removeMappingTitle": "Remove role?",
+  "removeMappingConfirm_one": "Are you sure you want to remove this role?",
+  "removeMappingConfirm_other": "Are you sure you want to remove {{count}} roles",
   "clientScopeSearch": {
     "name": "Name",
     "type": "Assigned type",


### PR DESCRIPTION
## Motivation
Closes #985 

## Verification Steps

1. Go to `Users > Role mapping > Select role > Click on Unassign`.
2. Verify that the world `mapping(s)` was replaced with the word `role(s)` 

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
