### PR TITLE
Add wait to 'enable user events' test

### DIFF
--- a/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
@@ -120,6 +120,7 @@ describe("Realm settings events tab tests", () => {
     masthead.checkNotificationMessage("Successfully saved configuration");
     cy.wait(["@fetchConfig"]);
     sidebarPage.waitForPageLoad();
+    cy.wait(1000);
     for (const event of events) {
       listingPage.searchItem(event, false).itemExist(event);
     }


### PR DESCRIPTION
Adds an arbitrary wait to the 'enable user events'  test. It looks like a re-render is causing the element reference to be lost, so hopefully this will allow it to settle.

Still need a better fix, as awaits are bad practice. For now this (hopefully) allows us to merge some PRs.