### PR TITLE
Added missing`url` types to KeycloakTextInput form fields - #1542

### DIFF
--- a/apps/admin-ui/src/clients/add/AccessSettings.tsx
+++ b/apps/admin-ui/src/clients/add/AccessSettings.tsx
@@ -49,7 +49,11 @@ export const AccessSettings = ({
               />
             }
           >
-            <KeycloakTextInput id="kc-root-url" {...register("rootUrl")} />
+            <KeycloakTextInput
+              id="kc-root-url"
+              type="url"
+              {...register("rootUrl")}
+            />
           </FormGroup>
           <FormGroup
             label={t("homeURL")}
@@ -61,7 +65,11 @@ export const AccessSettings = ({
               />
             }
           >
-            <KeycloakTextInput id="kc-home-url" {...register("baseUrl")} />
+            <KeycloakTextInput
+              id="kc-home-url"
+              type="url"
+              {...register("baseUrl")}
+            />
           </FormGroup>
           <FormGroup
             label={t("validRedirectUri")}
@@ -150,6 +158,7 @@ export const AccessSettings = ({
               >
                 <KeycloakTextInput
                   id="masterSamlProcessingUrl"
+                  type="url"
                   data-testid="masterSamlProcessingUrl"
                   {...register("adminUrl")}
                 />
@@ -187,7 +196,11 @@ export const AccessSettings = ({
             />
           }
         >
-          <KeycloakTextInput id="kc-admin-url" {...register("adminUrl")} />
+          <KeycloakTextInput
+            id="kc-admin-url"
+            type="url"
+            {...register("adminUrl")}
+          />
         </FormGroup>
       )}
       {client.bearerOnly && (

--- a/apps/admin-ui/src/clients/add/LogoutPanel.tsx
+++ b/apps/admin-ui/src/clients/add/LogoutPanel.tsx
@@ -84,6 +84,7 @@ export const LogoutPanel = ({
         >
           <KeycloakTextInput
             id="frontchannelLogoutUrl"
+            type="url"
             {...register(
               convertAttributeNameToForm<FormFields>(
                 "attributes.frontchannel.logout.url"
@@ -126,6 +127,7 @@ export const LogoutPanel = ({
           >
             <KeycloakTextInput
               id="backchannelLogoutUrl"
+              type="url"
               {...register(
                 convertAttributeNameToForm<FormFields>(
                   "attributes.backchannel.logout.url"

--- a/apps/admin-ui/src/clients/advanced/ApplicationUrls.tsx
+++ b/apps/admin-ui/src/clients/advanced/ApplicationUrls.tsx
@@ -25,6 +25,7 @@ export const ApplicationUrls = () => {
       >
         <KeycloakTextInput
           id="logoUrl"
+          type="url"
           data-testid="logoUrl"
           {...register(
             convertAttributeNameToForm<FormFields>("attributes.logoUri")
@@ -44,6 +45,7 @@ export const ApplicationUrls = () => {
         <KeycloakTextInput
           id="policyUrl"
           data-testid="policyUrl"
+          type="url"
           {...register(
             convertAttributeNameToForm<FormFields>("attributes.policyUri")
           )}
@@ -61,6 +63,7 @@ export const ApplicationUrls = () => {
       >
         <KeycloakTextInput
           id="termsOfServiceUrl"
+          type="url"
           data-testid="termsOfServiceUrl"
           {...register(
             convertAttributeNameToForm<FormFields>("attributes.tosUri")

--- a/apps/admin-ui/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
+++ b/apps/admin-ui/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
@@ -33,6 +33,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="assertionConsumerServicePostBindingURL"
+          type="url"
           {...register("attributes.saml_assertion_consumer_url_post")}
         />
       </FormGroup>
@@ -48,6 +49,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="assertionConsumerServiceRedirectBindingURL"
+          type="url"
           {...register("attributes.saml_assertion_consumer_url_redirect")}
         />
       </FormGroup>
@@ -63,6 +65,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="logoutServicePostBindingURL"
+          type="url"
           {...register("attributes.saml_single_logout_service_url_post")}
         />
       </FormGroup>
@@ -78,6 +81,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="logoutServiceRedirectBindingURL"
+          type="url"
           {...register("attributes.saml_single_logout_service_url_redirect")}
         />
       </FormGroup>
@@ -93,6 +97,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="logoutServiceArtifactBindingUrl"
+          type="url"
           {...register("attributes.saml_single_logout_service_url_artifact")}
         />
       </FormGroup>
@@ -108,6 +113,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="artifactBindingUrl"
+          type="url"
           {...register("attributes.saml_artifact_binding_url")}
         />
       </FormGroup>
@@ -123,6 +129,7 @@ export const FineGrainSamlEndpointConfig = ({
       >
         <KeycloakTextInput
           id="artifactResolutionService"
+          type="url"
           {...register("attributes.saml_artifact_resolution_service_url")}
         />
       </FormGroup>

--- a/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
+++ b/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
@@ -257,6 +257,7 @@ export default function ResourceDetails() {
             >
               <MultiLineInput
                 name="uris"
+                type="url"
                 aria-label={t("uris")}
                 addButtonLabel="clients:addUri"
               />
@@ -272,7 +273,12 @@ export default function ResourceDetails() {
                 />
               }
             >
-              <KeycloakTextInput id="iconUri" name="icon_uri" ref={register} />
+              <KeycloakTextInput
+                id="iconUri"
+                name="icon_uri"
+                type="url"
+                ref={register}
+              />
             </FormGroup>
             <FormGroup
               hasNoPaddingTop

--- a/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -182,6 +182,7 @@ export const Keys = ({ clientId, save, hasConfigureAccess }: KeysProps) => {
               >
                 <KeycloakTextInput
                   id="jwksUrl"
+                  type="url"
                   {...register(
                     convertAttributeNameToForm("attributes.jwks.url")
                   )}

--- a/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
+++ b/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
@@ -110,7 +110,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         helperTextInvalid={t("common:required")}
       >
         <KeycloakTextInput
-          type="text"
+          type="url"
           data-testid="sso-service-url"
           id="kc-sso-service-url"
           name="config.singleSignOnServiceUrl"
@@ -141,7 +141,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         helperTextInvalid={t("common:required")}
       >
         <KeycloakTextInput
-          type="text"
+          type="url"
           id="single-logout-service-url"
           name="config.singleLogoutServiceUrl"
           ref={register}

--- a/apps/admin-ui/src/identity-providers/add/DiscoverySettings.tsx
+++ b/apps/admin-ui/src/identity-providers/add/DiscoverySettings.tsx
@@ -59,7 +59,7 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
         helperTextInvalid={t("common:required")}
       >
         <KeycloakTextInput
-          type="text"
+          type="url"
           data-testid="authorizationUrl"
           id="kc-authorization-url"
           name="config.authorizationUrl"
@@ -85,7 +85,7 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
         helperTextInvalid={t("common:required")}
       >
         <KeycloakTextInput
-          type="text"
+          type="url"
           id="tokenUrl"
           data-testid="tokenUrl"
           name="config.tokenUrl"

--- a/apps/admin-ui/src/identity-providers/component/DiscoveryEndpointField.tsx
+++ b/apps/admin-ui/src/identity-providers/component/DiscoveryEndpointField.tsx
@@ -129,7 +129,7 @@ export const DiscoveryEndpointField = ({
           isRequired
         >
           <KeycloakTextInput
-            type="text"
+            type="url"
             name="discoveryEndpoint"
             data-testid="discoveryEndpoint"
             id="kc-discovery-endpoint"

--- a/apps/admin-ui/src/identity-providers/component/ExtendedFieldsForm.tsx
+++ b/apps/admin-ui/src/identity-providers/component/ExtendedFieldsForm.tsx
@@ -72,6 +72,7 @@ const GithubFields = () => {
       >
         <KeycloakTextInput
           id="baseUrl"
+          type="url"
           name="config.baseUrl"
           ref={register()}
         />
@@ -86,7 +87,12 @@ const GithubFields = () => {
         }
         fieldId="apiUrl"
       >
-        <KeycloakTextInput id="apiUrl" name="config.apiUrl" ref={register()} />
+        <KeycloakTextInput
+          id="apiUrl"
+          type="url"
+          name="config.apiUrl"
+          ref={register()}
+        />
       </FormGroup>
     </>
   );
@@ -197,6 +203,7 @@ const OpenshiftFields = () => {
     >
       <KeycloakTextInput
         id="baseUrl"
+        type="url"
         name="config.baseUrl"
         ref={register({ required: true })}
         isRequired

--- a/apps/admin-ui/src/realm-settings/GeneralTab.tsx
+++ b/apps/admin-ui/src/realm-settings/GeneralTab.tsx
@@ -115,7 +115,7 @@ export const RealmSettingsGeneralTab = ({
           }
         >
           <KeycloakTextInput
-            type="text"
+            type="url"
             id="kc-frontend-url"
             name={convertAttributeNameToForm("attributes.frontendUrl")}
             ref={register}

--- a/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -119,7 +119,7 @@ export const LdapSettingsConnection = ({
         >
           <KeycloakTextInput
             isRequired
-            type="text"
+            type="url"
             id="kc-console-connection-url"
             data-testid="ldap-connection-url"
             name="config.connectionUrl[0]"


### PR DESCRIPTION
## Motivation
Closes #1542 
Reviewed all forms (KeycloakTextInput) and identified a couple of possibly missing `url` types.  

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
