### PR TITLE
Upgrade `useParams()`  to React Router v6

### DIFF
--- a/apps/admin-ui/src/authentication/FlowDetails.tsx
+++ b/apps/admin-ui/src/authentication/FlowDetails.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useParams, useNavigate } from "react-router-dom-v5-compat";
 import { Trans, useTranslation } from "react-i18next";
 import {
   DataList,

--- a/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
+++ b/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
-import { useParams, useRouteMatch } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
+import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation";
+import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -13,22 +10,26 @@ import {
   PageSection,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation";
-import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
+import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useRouteMatch } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
+import { useAlerts } from "../../components/alert/Alerts";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import { HelpItem } from "../../components/help-enabler/HelpItem";
+import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { useAlerts } from "../../components/alert/Alerts";
-import { HelpItem } from "../../components/help-enabler/HelpItem";
+import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
-import { FormAccess } from "../../components/form-access/FormAccess";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { MapperParams, MapperRoute } from "../routes/Mapper";
+import { useParams } from "../../utils/useParams";
 import { toClientScope } from "../routes/ClientScope";
-import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
-import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
+import { MapperParams, MapperRoute } from "../routes/Mapper";
 
 import "./mapping-details.css";
 

--- a/apps/admin-ui/src/client-scopes/form/ClientScopeForm.tsx
+++ b/apps/admin-ui/src/client-scopes/form/ClientScopeForm.tsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
+import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation";
+import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
+import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import {
   AlertVariant,
   ButtonVariant,
@@ -10,31 +9,33 @@ import {
   Tab,
   TabTitleText,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { useAlerts } from "../../components/alert/Alerts";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { convertFormValuesToObject } from "../../util";
-import { MapperList } from "../details/MapperList";
-import { ScopeForm } from "../details/ScopeForm";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { RoleMapping, Row } from "../../components/role-mapping/RoleMapping";
-import type { RoleMappingPayload } from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
-import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
-import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation";
 import {
   AllClientScopes,
   changeScope,
   ClientScopeDefaultOptionalType,
 } from "../../components/client-scope/ClientScopeTypes";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import { toMapper } from "../routes/Mapper";
-import { ClientScopeTab, toClientScope } from "../routes/ClientScope";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { RoleMapping, Row } from "../../components/role-mapping/RoleMapping";
 import {
   routableTab,
   RoutableTabs,
 } from "../../components/routable-tabs/RoutableTabs";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { convertFormValuesToObject } from "../../util";
+import { useParams } from "../../utils/useParams";
+import { MapperList } from "../details/MapperList";
+import { ScopeForm } from "../details/ScopeForm";
+import { ClientScopeTab, toClientScope } from "../routes/ClientScope";
+import { toMapper } from "../routes/Mapper";
 
 export default function ClientScopeForm() {
   const { t } = useTranslation("client-scopes");

--- a/apps/admin-ui/src/clients/ClientDetails.tsx
+++ b/apps/admin-ui/src/clients/ClientDetails.tsx
@@ -20,8 +20,9 @@ import {
   useWatch,
 } from "react-hook-form-v7";
 import { useTranslation } from "react-i18next";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { useNavigate } from "react-router-dom-v5-compat";
+
 import { useAlerts } from "../components/alert/Alerts";
 import {
   ConfirmDialogModal,
@@ -50,6 +51,7 @@ import {
   convertToFormValues,
   exportClient,
 } from "../util";
+import { useParams } from "../utils/useParams";
 import useToggle from "../utils/useToggle";
 import { AdvancedTab } from "./AdvancedTab";
 import { AuthorizationEvaluate } from "./authorization/AuthorizationEvaluate";

--- a/apps/admin-ui/src/clients/authorization/AuthorizationEvaluateResourcePolicies.tsx
+++ b/apps/admin-ui/src/clients/authorization/AuthorizationEvaluateResourcePolicies.tsx
@@ -1,22 +1,23 @@
-import { useState } from "react";
+import type EvaluationResultRepresentation from "@keycloak/keycloak-admin-client/lib/defs/evaluationResultRepresentation";
+import { DecisionEffect } from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
+import type PolicyResultRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyResultRepresentation";
 import {
+  capitalize,
   DescriptionList,
   TextContent,
   TextList,
   TextListItem,
-  capitalize,
 } from "@patternfly/react-core";
-import { Tbody, Tr, Td, ExpandableRowContent } from "@patternfly/react-table";
+import { ExpandableRowContent, Tbody, Td, Tr } from "@patternfly/react-table";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import type PolicyResultRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyResultRepresentation";
-import type EvaluationResultRepresentation from "@keycloak/keycloak-admin-client/lib/defs/evaluationResultRepresentation";
-import { DecisionEffect } from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
-import { useParams } from "react-router-dom";
 import { Link } from "react-router-dom-v5-compat";
+
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { useParams } from "../../utils/useParams";
+import type { ClientParams } from "../routes/Client";
 import { toPermissionDetails } from "../routes/PermissionDetails";
 import { toPolicyDetails } from "../routes/PolicyDetails";
-import { useRealm } from "../../context/realm-context/RealmContext";
-import type { ClientParams } from "../routes/Client";
 
 type Props = {
   idx: number;

--- a/apps/admin-ui/src/clients/authorization/AuthorizationExport.tsx
+++ b/apps/admin-ui/src/clients/authorization/AuthorizationExport.tsx
@@ -1,24 +1,24 @@
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import {
+  ActionGroup,
+  AlertVariant,
+  Button,
   FormGroup,
   PageSection,
-  ActionGroup,
-  Button,
-  AlertVariant,
 } from "@patternfly/react-core";
+import { saveAs } from "file-saver";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
+import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
-import { saveAs } from "file-saver";
-import { prettyPrintJSON } from "../../util";
-import { useAlerts } from "../../components/alert/Alerts";
-import type { ClientParams } from "../routes/Client";
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextArea } from "../../components/keycloak-text-area/KeycloakTextArea";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { prettyPrintJSON } from "../../util";
+import { useParams } from "../../utils/useParams";
+import type { ClientParams } from "../routes/Client";
 
 import "./authorization-details.css";
 

--- a/apps/admin-ui/src/clients/authorization/PermissionDetails.tsx
+++ b/apps/admin-ui/src/clients/authorization/PermissionDetails.tsx
@@ -1,8 +1,4 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -15,26 +11,30 @@ import {
   SelectVariant,
   Switch,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
+import { useAlerts } from "../../components/alert/Alerts";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import { HelpItem } from "../../components/help-enabler/HelpItem";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { KeycloakTextArea } from "../../components/keycloak-text-area/KeycloakTextArea";
+import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { toUpperCase } from "../../util";
+import { useParams } from "../../utils/useParams";
+import { toAuthorizationTab } from "../routes/AuthenticationTab";
 import type { NewPermissionParams } from "../routes/NewPermission";
 import {
   PermissionDetailsParams,
   toPermissionDetails,
 } from "../routes/PermissionDetails";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { FormAccess } from "../../components/form-access/FormAccess";
-import { useAlerts } from "../../components/alert/Alerts";
-import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { ResourcesPolicySelect } from "./ResourcesPolicySelect";
-import { toAuthorizationTab } from "../routes/AuthenticationTab";
 import { ScopeSelect } from "./ScopeSelect";
-import { toUpperCase } from "../../util";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { KeycloakTextArea } from "../../components/keycloak-text-area/KeycloakTextArea";
 
 const DECISION_STRATEGIES = ["UNANIMOUS", "AFFIRMATIVE", "CONSENSUS"] as const;
 

--- a/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
+++ b/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { Controller, FormProvider, useForm } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
+import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import {
   ActionGroup,
   Alert,
@@ -15,25 +13,27 @@ import {
   Switch,
   ValidatedOptions,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
-import { ResourceDetailsParams, toResourceDetails } from "../routes/Resource";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { useAlerts } from "../../components/alert/Alerts";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { FormAccess } from "../../components/form-access/FormAccess";
+import { HelpItem } from "../../components/help-enabler/HelpItem";
 import type { KeyValueType } from "../../components/key-value-form/key-value-convert";
-import { convertFormValuesToObject, convertToFormValues } from "../../util";
-import { MultiLineInput } from "../../components/multi-line-input/MultiLineInput";
-import { toAuthorizationTab } from "../routes/AuthenticationTab";
-import { ScopePicker } from "./ScopePicker";
 import { KeyValueInput } from "../../components/key-value-form/KeyValueInput";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
+import { MultiLineInput } from "../../components/multi-line-input/MultiLineInput";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { convertFormValuesToObject, convertToFormValues } from "../../util";
+import { useParams } from "../../utils/useParams";
+import { toAuthorizationTab } from "../routes/AuthenticationTab";
+import { ResourceDetailsParams, toResourceDetails } from "../routes/Resource";
+import { ScopePicker } from "./ScopePicker";
 
 import "./resource-details.css";
 

--- a/apps/admin-ui/src/clients/authorization/ScopeDetails.tsx
+++ b/apps/admin-ui/src/clients/authorization/ScopeDetails.tsx
@@ -12,7 +12,6 @@ import {
 import { useState } from "react";
 import { useForm } from "react-hook-form-v7";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom-v5-compat";
 
 import { useAlerts } from "../../components/alert/Alerts";
@@ -21,6 +20,7 @@ import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useParams } from "../../utils/useParams";
 import useToggle from "../../utils/useToggle";
 import { toAuthorizationTab } from "../routes/AuthenticationTab";
 import type { ScopeDetailsParams } from "../routes/Scope";

--- a/apps/admin-ui/src/clients/authorization/policy/Aggregate.tsx
+++ b/apps/admin-ui/src/clients/authorization/policy/Aggregate.tsx
@@ -1,11 +1,11 @@
-import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { FormGroup } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
 
-import type { PolicyDetailsParams } from "../../routes/PolicyDetails";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
-import { ResourcesPolicySelect } from "../ResourcesPolicySelect";
+import { useParams } from "../../../utils/useParams";
+import type { PolicyDetailsParams } from "../../routes/PolicyDetails";
 import { DecisionStrategySelect } from "../DecisionStragegySelect";
+import { ResourcesPolicySelect } from "../ResourcesPolicySelect";
 
 export const Aggregate = () => {
   const { t } = useTranslation("clients");

--- a/apps/admin-ui/src/clients/authorization/policy/PolicyDetails.tsx
+++ b/apps/admin-ui/src/clients/authorization/policy/PolicyDetails.tsx
@@ -1,8 +1,4 @@
-import { FunctionComponent, useState } from "react";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -11,30 +7,34 @@ import {
   DropdownItem,
   PageSection,
 } from "@patternfly/react-core";
+import { FunctionComponent, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
+import { useAlerts } from "../../../components/alert/Alerts";
+import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
+import { FormAccess } from "../../../components/form-access/FormAccess";
+import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
+import { ViewHeader } from "../../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useParams } from "../../../utils/useParams";
+import { toAuthorizationTab } from "../../routes/AuthenticationTab";
 import {
   PolicyDetailsParams,
   toPolicyDetails,
 } from "../../routes/PolicyDetails";
-import { ViewHeader } from "../../../components/view-header/ViewHeader";
-import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
-import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
-import { FormAccess } from "../../../components/form-access/FormAccess";
-import { useAlerts } from "../../../components/alert/Alerts";
-import { toAuthorizationTab } from "../../routes/AuthenticationTab";
 import { Aggregate } from "./Aggregate";
 import { Client } from "./Client";
-import { User } from "./User";
-import { NameDescription } from "./NameDescription";
-import { LogicSelector } from "./LogicSelector";
 import { ClientScope, RequiredIdValue } from "./ClientScope";
 import { Group, GroupValue } from "./Group";
+import { JavaScript } from "./JavaScript";
+import { LogicSelector } from "./LogicSelector";
+import { NameDescription } from "./NameDescription";
 import { Regex } from "./Regex";
 import { Role } from "./Role";
 import { Time } from "./Time";
-import { JavaScript } from "./JavaScript";
+import { User } from "./User";
 
 import "./policy-details.css";
 

--- a/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
+++ b/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
@@ -1,32 +1,33 @@
-import { useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation";
+import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import {
   AlertVariant,
   PageSection,
   Tab,
   TabTitleText,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
-import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
-import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { MapperList } from "../../client-scopes/details/MapperList";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useAlerts } from "../../components/alert/Alerts";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import {
   routableTab,
   RoutableTabs,
 } from "../../components/routable-tabs/RoutableTabs";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useParams } from "../../utils/useParams";
 import {
   DedicatedScopeDetailsParams,
   DedicatedScopeTab,
   toDedicatedScope,
 } from "../routes/DedicatedScopeDetails";
 import { toMapper } from "../routes/Mapper";
-import { useAlerts } from "../../components/alert/Alerts";
 import { DedicatedScope } from "./DecicatedScope";
 
 export default function DedicatedScopes() {

--- a/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
@@ -1,26 +1,26 @@
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import {
   ActionGroup,
   AlertVariant,
   Button,
   PageSection,
 } from "@patternfly/react-core";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
-import { ExtendedFieldsForm } from "../component/ExtendedFieldsForm";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { toUpperCase } from "../../util";
+import { useAlerts } from "../../components/alert/Alerts";
 import { FormAccess } from "../../components/form-access/FormAccess";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
 import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { useAlerts } from "../../components/alert/Alerts";
-import { GeneralSettings } from "./GeneralSettings";
+import { toUpperCase } from "../../util";
+import { useParams } from "../../utils/useParams";
+import { ExtendedFieldsForm } from "../component/ExtendedFieldsForm";
 import { toIdentityProvider } from "../routes/IdentityProvider";
 import type { IdentityProviderCreateParams } from "../routes/IdentityProviderCreate";
 import { toIdentityProviders } from "../routes/IdentityProviders";
+import { GeneralSettings } from "./GeneralSettings";
 
 export default function AddIdentityProvider() {
   const { t } = useTranslation("identity-providers");

--- a/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
+++ b/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
+import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
+import type { IdentityProviderMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperTypeRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -13,30 +11,30 @@ import {
   PageSection,
   ValidatedOptions,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import { useRealm } from "../../context/realm-context/RealmContext";
-
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { FormAccess } from "../../components/form-access/FormAccess";
-import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import type { IdentityProviderAddMapperParams } from "../routes/AddMapper";
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import { useAlerts } from "../../components/alert/Alerts";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import type { AttributeForm } from "../../components/key-value-form/AttributeForm";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { convertFormValuesToObject, convertToFormValues } from "../../util";
+import useLocaleSort, { mapByKey } from "../../utils/useLocaleSort";
+import { useParams } from "../../utils/useParams";
 import {
   IdentityProviderEditMapperParams,
   toIdentityProviderEditMapper,
 } from "../routes/EditMapper";
-import { convertFormValuesToObject, convertToFormValues } from "../../util";
 import { toIdentityProvider } from "../routes/IdentityProvider";
-import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
-import type { IdentityProviderMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperTypeRepresentation";
 import { AddMapperForm } from "./AddMapperForm";
-import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import type { AttributeForm } from "../../components/key-value-form/AttributeForm";
-import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
-import useLocaleSort, { mapByKey } from "../../utils/useLocaleSort";
 
 export type IdPMapperRepresentationWithAttributes =
   IdentityProviderMapperRepresentation & AttributeForm;
@@ -59,8 +57,8 @@ export default function AddMapper() {
   const { realm } = useRealm();
   const { adminClient } = useAdminClient();
 
-  const { providerId, alias } = useParams<IdentityProviderAddMapperParams>();
-  const { id } = useParams<IdentityProviderEditMapperParams>();
+  const { id, providerId, alias } =
+    useParams<IdentityProviderEditMapperParams>();
 
   const [mapperTypes, setMapperTypes] =
     useState<IdentityProviderMapperTypeRepresentation[]>();

--- a/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { Controller, FormProvider, useForm } from "react-hook-form";
+import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -16,41 +13,43 @@ import {
   TabTitleText,
   ToolbarItem,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
-import { FormAccess } from "../../components/form-access/FormAccess";
-import { ScrollForm } from "../../components/scroll-form/ScrollForm";
-import { ViewHeader } from "../../components/view-header/ViewHeader";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
-import { useFetch, useAdminClient } from "../../context/auth/AdminClient";
-import { GeneralSettings } from "./GeneralSettings";
-import { AdvancedSettings } from "./AdvancedSettings";
-import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { useAlerts } from "../../components/alert/Alerts";
+import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
+import { FormAccess } from "../../components/form-access/FormAccess";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
+import { KeycloakTabs } from "../../components/keycloak-tabs/KeycloakTabs";
+import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
+import { PermissionsTab } from "../../components/permission-tab/PermissionTab";
+import { ScrollForm } from "../../components/scroll-form/ScrollForm";
+import { KeycloakDataTable } from "../../components/table-toolbar/KeycloakDataTable";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
-import { KeycloakTabs } from "../../components/keycloak-tabs/KeycloakTabs";
-import { ExtendedNonDiscoverySettings } from "./ExtendedNonDiscoverySettings";
-import { DiscoverySettings } from "./DiscoverySettings";
-import { DescriptorSettings } from "./DescriptorSettings";
-import { OIDCGeneralSettings } from "./OIDCGeneralSettings";
-import { SamlGeneralSettings } from "./SamlGeneralSettings";
-import { OIDCAuthentication } from "./OIDCAuthentication";
-import { ReqAuthnConstraints } from "./ReqAuthnConstraintsSettings";
-import { KeycloakDataTable } from "../../components/table-toolbar/KeycloakDataTable";
-import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
-import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
+import { toUpperCase } from "../../util";
+import { useParams } from "../../utils/useParams";
+import { ExtendedFieldsForm } from "../component/ExtendedFieldsForm";
 import { toIdentityProviderAddMapper } from "../routes/AddMapper";
 import { toIdentityProviderEditMapper } from "../routes/EditMapper";
-import { toIdentityProviders } from "../routes/IdentityProviders";
-
-import { toUpperCase } from "../../util";
 import {
   IdentityProviderParams,
   toIdentityProvider,
 } from "../routes/IdentityProvider";
-import { PermissionsTab } from "../../components/permission-tab/PermissionTab";
-import { ExtendedFieldsForm } from "../component/ExtendedFieldsForm";
+import { toIdentityProviders } from "../routes/IdentityProviders";
+import { AdvancedSettings } from "./AdvancedSettings";
+import { DescriptorSettings } from "./DescriptorSettings";
+import { DiscoverySettings } from "./DiscoverySettings";
+import { ExtendedNonDiscoverySettings } from "./ExtendedNonDiscoverySettings";
+import { GeneralSettings } from "./GeneralSettings";
+import { OIDCAuthentication } from "./OIDCAuthentication";
+import { OIDCGeneralSettings } from "./OIDCGeneralSettings";
+import { ReqAuthnConstraints } from "./ReqAuthnConstraintsSettings";
+import { SamlGeneralSettings } from "./SamlGeneralSettings";
 
 type HeaderProps = {
   onChange: (value: boolean) => void;

--- a/apps/admin-ui/src/identity-providers/add/OIDCGeneralSettings.tsx
+++ b/apps/admin-ui/src/identity-providers/add/OIDCGeneralSettings.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";
+import { useParams } from "react-router-dom-v5-compat";
 
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { RedirectUrl } from "../component/RedirectUrl";
@@ -8,7 +9,6 @@ import { TextField } from "../component/TextField";
 import { DisplayOrder } from "../component/DisplayOrder";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import type { IdentityProviderParams } from "../routes/IdentityProvider";
-import { useParams } from "react-router-dom";
 
 export const OIDCGeneralSettings = ({ id }: { id: string }) => {
   const { t } = useTranslation("identity-providers");

--- a/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
+++ b/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { useParams, useRouteMatch } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import {
   AlertVariant,
   ButtonVariant,
@@ -9,39 +8,41 @@ import {
   Tab,
   TabTitleText,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { useForm } from "react-hook-form";
 import { omit } from "lodash-es";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useRouteMatch } from "react-router-dom";
+import { useNavigate } from "react-router-dom-v5-compat";
 
 import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { useServerInfo } from "../context/server-info/ServerInfoProvider";
-import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import {
-  AttributesForm,
   AttributeForm,
+  AttributesForm,
 } from "../components/key-value-form/AttributeForm";
 import {
   arrayToKeyValue,
   keyValueToArray,
 } from "../components/key-value-form/key-value-convert";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
-import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { RealmRoleForm } from "./RealmRoleForm";
-import { useRealm } from "../context/realm-context/RealmContext";
-import { AddRoleMappingModal } from "../components/role-mapping/AddRoleMappingModal";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
-import { UsersInRoleTab } from "./UsersInRoleTab";
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import { toRealmRole } from "./routes/RealmRole";
+import { PermissionsTab } from "../components/permission-tab/PermissionTab";
+import { AddRoleMappingModal } from "../components/role-mapping/AddRoleMappingModal";
+import { RoleMapping } from "../components/role-mapping/RoleMapping";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useRealm } from "../context/realm-context/RealmContext";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { useParams } from "../utils/useParams";
+import { RealmRoleForm } from "./RealmRoleForm";
 import {
   ClientRoleParams,
   ClientRoleRoute,
   toClientRole,
 } from "./routes/ClientRole";
-import { PermissionsTab } from "../components/permission-tab/PermissionTab";
-import { RoleMapping } from "../components/role-mapping/RoleMapping";
+import { toRealmRole } from "./routes/RealmRole";
+import { UsersInRoleTab } from "./UsersInRoleTab";
 
 export default function RealmRoleTabs() {
   const { t } = useTranslation("roles");

--- a/apps/admin-ui/src/realm-roles/UsersInRoleTab.tsx
+++ b/apps/admin-ui/src/realm-roles/UsersInRoleTab.tsx
@@ -1,15 +1,15 @@
 import { Button, PageSection, Popover } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
-
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom-v5-compat";
+
 import { useHelp } from "../components/help-enabler/HelpHeader";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { emptyFormatter, upperCaseFormatter } from "../util";
+import { useParams } from "../utils/useParams";
 import type { ClientRoleParams } from "./routes/ClientRole";
 
 export const UsersInRoleTab = () => {

--- a/apps/admin-ui/src/realm-settings/ClientProfileForm.tsx
+++ b/apps/admin-ui/src/realm-settings/ClientProfileForm.tsx
@@ -1,7 +1,6 @@
-import { Fragment, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
-import { useForm, useFieldArray } from "react-hook-form";
+import type ClientPolicyExecutorRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientPolicyExecutorRepresentation";
+import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
+import type ClientProfilesRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfilesRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -17,32 +16,33 @@ import {
   Flex,
   FlexItem,
   FormGroup,
+  Label,
   PageSection,
   Text,
   TextVariants,
   ValidatedOptions,
-  Label,
 } from "@patternfly/react-core";
-
-import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
-import type ClientProfilesRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfilesRepresentation";
-import type ClientPolicyExecutorRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientPolicyExecutorRepresentation";
-import { FormAccess } from "../components/form-access/FormAccess";
-import { ViewHeader } from "../components/view-header/ViewHeader";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { HelpItem } from "../components/help-enabler/HelpItem";
-import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
-import { KeycloakTextArea } from "../components/keycloak-text-area/KeycloakTextArea";
 import { PlusCircleIcon, TrashIcon } from "@patternfly/react-icons";
+import { Fragment, useMemo, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
+
+import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { toAddExecutor } from "./routes/AddExecutor";
+import { FormAccess } from "../components/form-access/FormAccess";
+import { HelpItem } from "../components/help-enabler/HelpItem";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { KeycloakTextArea } from "../components/keycloak-text-area/KeycloakTextArea";
+import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { useParams } from "../utils/useParams";
+import { toAddExecutor } from "./routes/AddExecutor";
+import { toClientPolicies } from "./routes/ClientPolicies";
 import { ClientProfileParams, toClientProfile } from "./routes/ClientProfile";
 import { toExecutor } from "./routes/Executor";
-import { toClientPolicies } from "./routes/ClientPolicies";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 
 import "./realm-settings-section.css";
 

--- a/apps/admin-ui/src/realm-settings/ExecutorForm.tsx
+++ b/apps/admin-ui/src/realm-settings/ExecutorForm.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
+import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
+import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -9,21 +11,20 @@ import {
   SelectOption,
   SelectVariant,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { FormAccess } from "../components/form-access/FormAccess";
-import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useAlerts } from "../components/alert/Alerts";
-import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { HelpItem } from "../components/help-enabler/HelpItem";
-import { useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
-import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
-import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
-import { ClientProfileParams, toClientProfile } from "./routes/ClientProfile";
+
+import { useAlerts } from "../components/alert/Alerts";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
+import { FormAccess } from "../components/form-access/FormAccess";
+import { HelpItem } from "../components/help-enabler/HelpItem";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { useParams } from "../utils/useParams";
+import { ClientProfileParams, toClientProfile } from "./routes/ClientProfile";
 import type { ExecutorParams } from "./routes/Executor";
 
 type ExecutorForm = {

--- a/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import type UserProfileConfig from "@keycloak/keycloak-admin-client/lib/defs/userProfileConfig";
+import type { UserProfileAttribute } from "@keycloak/keycloak-admin-client/lib/defs/userProfileConfig";
 import {
   ActionGroup,
   AlertVariant,
@@ -6,25 +7,25 @@ import {
   Form,
   PageSection,
 } from "@patternfly/react-core";
+import { flatten } from "flat";
+import { useState } from "react";
 import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { Link, useNavigate } from "react-router-dom-v5-compat";
+
+import { useAlerts } from "../components/alert/Alerts";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
-import type UserProfileConfig from "@keycloak/keycloak-admin-client/lib/defs/userProfileConfig";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { convertToFormValues } from "../util";
+import { useParams } from "../utils/useParams";
+import type { AttributeParams } from "./routes/Attribute";
+import { toUserProfile } from "./routes/UserProfile";
+import { AttributeAnnotations } from "./user-profile/attribute/AttributeAnnotations";
 import { AttributeGeneralSettings } from "./user-profile/attribute/AttributeGeneralSettings";
 import { AttributePermission } from "./user-profile/attribute/AttributePermission";
 import { AttributeValidations } from "./user-profile/attribute/AttributeValidations";
-import { toUserProfile } from "./routes/UserProfile";
-import { ViewHeader } from "../components/view-header/ViewHeader";
-import { AttributeAnnotations } from "./user-profile/attribute/AttributeAnnotations";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { useAlerts } from "../components/alert/Alerts";
 import { UserProfileProvider } from "./user-profile/UserProfileContext";
-import type { UserProfileAttribute } from "@keycloak/keycloak-admin-client/lib/defs/userProfileConfig";
-import type { AttributeParams } from "./routes/Attribute";
-import { convertToFormValues } from "../util";
-import { flatten } from "flat";
 
 import "./realm-settings-section.css";
 

--- a/apps/admin-ui/src/realm-settings/NewClientPolicyCondition.tsx
+++ b/apps/admin-ui/src/realm-settings/NewClientPolicyCondition.tsx
@@ -20,8 +20,7 @@ import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib
 import { camelCase } from "lodash-es";
 import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import { useAlerts } from "../components/alert/Alerts";
-import { useParams } from "react-router";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useParams, useNavigate } from "react-router-dom-v5-compat";
 import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
 import { useRealm } from "../context/realm-context/RealmContext";
 import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";

--- a/apps/admin-ui/src/realm-settings/NewClientPolicyForm.tsx
+++ b/apps/admin-ui/src/realm-settings/NewClientPolicyForm.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientPolicyRepresentation";
+import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -19,35 +20,34 @@ import {
   TextVariants,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import { Controller, useForm } from "react-hook-form";
-import { FormAccess } from "../components/form-access/FormAccess";
-import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useRealm } from "../context/realm-context/RealmContext";
-import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { HelpItem } from "../components/help-enabler/HelpItem";
-import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
-import { KeycloakTextArea } from "../components/keycloak-text-area/KeycloakTextArea";
 import { PlusCircleIcon, TrashIcon } from "@patternfly/react-icons";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientPolicyRepresentation";
-import { toNewClientPolicyCondition } from "./routes/AddCondition";
-import { useServerInfo } from "../context/server-info/ServerInfoProvider";
-import { toEditClientPolicyCondition } from "./routes/EditCondition";
-import { toClientProfile } from "./routes/ClientProfile";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
+import { useAlerts } from "../components/alert/Alerts";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { FormAccess } from "../components/form-access/FormAccess";
+import { HelpItem } from "../components/help-enabler/HelpItem";
+import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { KeycloakTextArea } from "../components/keycloak-text-area/KeycloakTextArea";
+import { KeycloakTextInput } from "../components/keycloak-text-input/KeycloakTextInput";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useRealm } from "../context/realm-context/RealmContext";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { AddClientProfileModal } from "./AddClientProfileModal";
+import { toNewClientPolicyCondition } from "./routes/AddCondition";
+import { toClientPolicies } from "./routes/ClientPolicies";
+import { toClientProfile } from "./routes/ClientProfile";
 import {
   EditClientPolicyParams,
   toEditClientPolicy,
 } from "./routes/EditClientPolicy";
-import { AddClientProfileModal } from "./AddClientProfileModal";
-import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
-import { toClientPolicies } from "./routes/ClientPolicies";
-import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
+import { toEditClientPolicyCondition } from "./routes/EditCondition";
 
+import { useParams } from "../utils/useParams";
 import "./realm-settings-section.css";
 
 type NewClientPolicyForm = Required<ClientPolicyRepresentation>;

--- a/apps/admin-ui/src/realm-settings/RealmSettingsSection.tsx
+++ b/apps/admin-ui/src/realm-settings/RealmSettingsSection.tsx
@@ -1,11 +1,11 @@
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import { useState } from "react";
 
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import type { RealmSettingsParams } from "./routes/RealmSettings";
 import { KeycloakSpinner } from "../components/keycloak-spinner/KeycloakSpinner";
 import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useParams } from "../utils/useParams";
 import { RealmSettingsTabs } from "./RealmSettingsTabs";
-import { useParams } from "react-router-dom";
+import type { RealmSettingsParams } from "./routes/RealmSettings";
 
 export default function RealmSettingsSection() {
   const { adminClient } = useAdminClient();

--- a/apps/admin-ui/src/realm-settings/keys/key-providers/KeyProviderForm.tsx
+++ b/apps/admin-ui/src/realm-settings/keys/key-providers/KeyProviderForm.tsx
@@ -1,27 +1,27 @@
-import { useParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
-import { Controller, FormProvider, useForm } from "react-hook-form";
-import {
-  AlertVariant,
-  FormGroup,
-  ValidatedOptions,
-  TextInput,
-  PageSection,
-  ActionGroup,
-  Button,
-} from "@patternfly/react-core";
-
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import type { KeyProviderParams, ProviderType } from "../../routes/KeyProvider";
+import {
+  ActionGroup,
+  AlertVariant,
+  Button,
+  FormGroup,
+  PageSection,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
 import { useAlerts } from "../../../components/alert/Alerts";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { DynamicComponents } from "../../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../../components/form-access/FormAccess";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
-import { KEY_PROVIDER_TYPE } from "../../../util";
-import { ViewHeader } from "../../../components/view-header/ViewHeader";
-import { DynamicComponents } from "../../../components/dynamic/DynamicComponents";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
+import { ViewHeader } from "../../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
 import { useServerInfo } from "../../../context/server-info/ServerInfoProvider";
+import { KEY_PROVIDER_TYPE } from "../../../util";
+import { useParams } from "../../../utils/useParams";
+import type { KeyProviderParams, ProviderType } from "../../routes/KeyProvider";
 
 type KeyProviderFormProps = {
   id?: string;

--- a/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
+++ b/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupForm.tsx
@@ -10,18 +10,18 @@ import {
 import { useEffect, useMemo } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { KeyValueInput } from "../../components/key-value-form/KeyValueInput";
+import { Link, useNavigate, useParams } from "react-router-dom-v5-compat";
+
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
+import type { KeyValueType } from "../../components/key-value-form/key-value-convert";
+import { KeyValueInput } from "../../components/key-value-form/KeyValueInput";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import type { EditAttributesGroupParams } from "../routes/EditAttributesGroup";
 import { toUserProfile } from "../routes/UserProfile";
 import { useUserProfile } from "./UserProfileContext";
-import type { KeyValueType } from "../../components/key-value-form/key-value-convert";
 
 import "../realm-settings-section.css";
 
@@ -59,7 +59,7 @@ export default function AttributesGroupForm() {
   const { realm } = useRealm();
   const { config, save } = useUserProfile();
   const navigate = useNavigate();
-  const params = useParams<Partial<EditAttributesGroupParams>>();
+  const params = useParams<EditAttributesGroupParams>();
   const form = useForm<FormFields>({ defaultValues, shouldUnregister: false });
 
   const matchingGroup = useMemo(

--- a/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
+++ b/apps/admin-ui/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
@@ -13,12 +13,13 @@ import { isEqual } from "lodash-es";
 import { useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+
 import { FormAccess } from "../../../components/form-access/FormAccess";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
 import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
 import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useParams } from "../../../utils/useParams";
 import { USERNAME_EMAIL } from "../../NewAttributeSettings";
 import type { AttributeParams } from "../../routes/Attribute";
 

--- a/apps/admin-ui/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/apps/admin-ui/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,3 +1,4 @@
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -5,20 +6,18 @@ import {
   Form,
   PageSection,
 } from "@patternfly/react-core";
-
-import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
-import { SettingsCache } from "./shared/SettingsCache";
-import { useRealm } from "../context/realm-context/RealmContext";
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-
 import { FormProvider, useForm } from "react-hook-form";
-import { useAdminClient, useFetch } from "../context/auth/AdminClient";
-import { useAlerts } from "../components/alert/Alerts";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom-v5-compat";
-import { Header } from "./shared/Header";
+
+import { useAlerts } from "../components/alert/Alerts";
+import { useAdminClient, useFetch } from "../context/auth/AdminClient";
+import { useRealm } from "../context/realm-context/RealmContext";
+import { useParams } from "../utils/useParams";
+import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
 import { toUserFederation } from "./routes/UserFederation";
+import { Header } from "./shared/Header";
+import { SettingsCache } from "./shared/SettingsCache";
 
 export default function UserFederationKerberosSettings() {
   const { t } = useTranslation("user-federation");

--- a/apps/admin-ui/src/user-federation/UserFederationLdapSettings.tsx
+++ b/apps/admin-ui/src/user-federation/UserFederationLdapSettings.tsx
@@ -24,8 +24,8 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import { useAlerts } from "../components/alert/Alerts";
 import { useTranslation } from "react-i18next";
-import { useHistory, useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useHistory } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom-v5-compat";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
 
 import { LdapMapperList } from "./ldap/mappers/LdapMapperList";

--- a/apps/admin-ui/src/user-federation/custom/CustomProviderSettings.tsx
+++ b/apps/admin-ui/src/user-federation/custom/CustomProviderSettings.tsx
@@ -1,8 +1,4 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
-import { useTranslation } from "react-i18next";
-import { FormProvider, useForm } from "react-hook-form";
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -10,21 +6,25 @@ import {
   FormGroup,
   PageSection,
 } from "@patternfly/react-core";
+import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom-v5-compat";
 
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import type { ProviderRouteParams } from "../routes/NewProvider";
-import { HelpItem } from "../../components/help-enabler/HelpItem";
+import { useAlerts } from "../../components/alert/Alerts";
+import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
 import { FormAccess } from "../../components/form-access/FormAccess";
+import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
-import { toUserFederation } from "../routes/UserFederation";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { useAlerts } from "../../components/alert/Alerts";
-import { SettingsCache } from "../shared/SettingsCache";
-import { ExtendedHeader } from "../shared/ExtendedHeader";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
-import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
 import { convertFormValuesToObject, convertToFormValues } from "../../util";
+import { useParams } from "../../utils/useParams";
+import type { ProviderRouteParams } from "../routes/NewProvider";
+import { toUserFederation } from "../routes/UserFederation";
+import { ExtendedHeader } from "../shared/ExtendedHeader";
+import { SettingsCache } from "../shared/SettingsCache";
 import { SyncSettings } from "./SyncSettings";
 
 import "./custom-provider-settings.css";

--- a/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
+import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
 import {
   ActionGroup,
   AlertVariant,
@@ -13,26 +14,25 @@ import {
   SelectVariant,
   ValidatedOptions,
 } from "@patternfly/react-core";
-import { convertFormValuesToObject, convertToFormValues } from "../../../util";
-import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
-import { ViewHeader } from "../../../components/view-header/ViewHeader";
-import { useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { DirectionType } from "libs/keycloak-admin-client/lib/resources/userStorageProvider";
+import { useState } from "react";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
-import { useAlerts } from "../../../components/alert/Alerts";
 import { useTranslation } from "react-i18next";
-import { HelpItem } from "../../../components/help-enabler/HelpItem";
-import { FormAccess } from "../../../components/form-access/FormAccess";
+import { useNavigate } from "react-router-dom-v5-compat";
 
-import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
+import { useAlerts } from "../../../components/alert/Alerts";
+import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
 import { DynamicComponents } from "../../../components/dynamic/DynamicComponents";
-import { useRealm } from "../../../context/realm-context/RealmContext";
+import { FormAccess } from "../../../components/form-access/FormAccess";
+import { HelpItem } from "../../../components/help-enabler/HelpItem";
 import { KeycloakSpinner } from "../../../components/keycloak-spinner/KeycloakSpinner";
 import { KeycloakTextInput } from "../../../components/keycloak-text-input/KeycloakTextInput";
+import { ViewHeader } from "../../../components/view-header/ViewHeader";
+import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+import { useRealm } from "../../../context/realm-context/RealmContext";
+import { convertFormValuesToObject, convertToFormValues } from "../../../util";
+import { useParams } from "../../../utils/useParams";
 import { toUserFederationLdap } from "../../routes/UserFederationLdap";
-import { useConfirmDialog } from "../../../components/confirm-dialog/ConfirmDialog";
-import { DirectionType } from "libs/keycloak-admin-client/lib/resources/userStorageProvider";
 
 export default function LdapMapperDetails() {
   const form = useForm<ComponentRepresentation>();

--- a/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperList.tsx
+++ b/apps/admin-ui/src/user-federation/ldap/mappers/LdapMapperList.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useParams, useRouteMatch } from "react-router-dom";
-import { Link, useNavigate } from "react-router-dom-v5-compat";
+import { useRouteMatch } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/apps/admin-ui/src/user-federation/shared/ExtendedHeader.tsx
+++ b/apps/admin-ui/src/user-federation/shared/ExtendedHeader.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/apps/admin-ui/src/user-federation/shared/Header.tsx
+++ b/apps/admin-ui/src/user-federation/shared/Header.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from "react";
-import { useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useParams, useNavigate } from "react-router-dom-v5-compat";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/apps/admin-ui/src/user/UserConsents.tsx
+++ b/apps/admin-ui/src/user/UserConsents.tsx
@@ -1,23 +1,24 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import type UserConsentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userConsentRepresentation";
 import {
   AlertVariant,
   ButtonVariant,
   Chip,
   ChipGroup,
 } from "@patternfly/react-core";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { emptyFormatter } from "../util";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { CubesIcon } from "@patternfly/react-icons";
 import { cellWidth } from "@patternfly/react-table";
 import { sortBy } from "lodash-es";
-import type UserConsentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userConsentRepresentation";
-import { CubesIcon } from "@patternfly/react-icons";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
 import { useAlerts } from "../components/alert/Alerts";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { emptyFormatter } from "../util";
 import useFormatDate from "../utils/useFormatDate";
+import { useParams } from "../utils/useParams";
 
 export const UserConsents = () => {
   const [selectedClient, setSelectedClient] =

--- a/apps/admin-ui/src/user/UserSessions.tsx
+++ b/apps/admin-ui/src/user/UserSessions.tsx
@@ -1,11 +1,10 @@
 import { PageSection } from "@patternfly/react-core";
-
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 
 import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import SessionsTable from "../sessions/SessionsTable";
+import { useParams } from "../utils/useParams";
 import type { UserParams } from "./routes/User";
 
 export const UserSessions = () => {

--- a/apps/admin-ui/src/user/UsersTabs.tsx
+++ b/apps/admin-ui/src/user/UsersTabs.tsx
@@ -11,7 +11,6 @@ import {
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom-v5-compat";
 
 import { useAlerts } from "../components/alert/Alerts";
@@ -22,6 +21,8 @@ import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAccess } from "../context/access/Access";
 import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
+import { UserProfileProvider } from "../realm-settings/user-profile/UserProfileContext";
+import { useParams } from "../utils/useParams";
 import { toUser, UserParams } from "./routes/User";
 import { toUsers } from "./routes/Users";
 import { UserAttributes } from "./UserAttributes";
@@ -32,7 +33,7 @@ import { UserGroups } from "./UserGroups";
 import { UserIdentityProviderLinks } from "./UserIdentityProviderLinks";
 import { UserRoleMapping } from "./UserRoleMapping";
 import { UserSessions } from "./UserSessions";
-import { UserProfileProvider } from "../realm-settings/user-profile/UserProfileContext";
+
 import "./user-section.css";
 
 const UsersTabs = () => {

--- a/apps/admin-ui/src/utils/useParams.ts
+++ b/apps/admin-ui/src/utils/useParams.ts
@@ -1,0 +1,4 @@
+import { useParams as useParamsRR } from "react-router-dom-v5-compat";
+
+export const useParams = <T extends Record<string, string>>() =>
+  useParamsRR<T>() as T;


### PR DESCRIPTION
Replaces calls to `useParams()` with the compatibility library version for React Router v6.