### PR TITLE
Download latest version of Chrome for Cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -124,6 +124,12 @@ jobs:
           KEYCLOAK_ADMIN: admin
           KEYCLOAK_ADMIN_PASSWORD: admin
 
+      - name: Install Google Chrome
+        uses: abhi1693/setup-browser@v0.3.4
+        with:
+          browser: chrome
+          version: latest
+
       - name: Run Cypress
         uses: cypress-io/github-action@v5
         continue-on-error: true


### PR DESCRIPTION
Sometimes the version of Google Chrome can be different between Github Action runners. This causes the Cypress tests to fail. This additional step ensures that we're always running the latest version of Google Chrome.