### PR TITLE
Fixed navigation to mappers tab in identity providers #1355

### DIFF
--- a/apps/admin-ui/cypress/e2e/identity_providers_oidc_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/identity_providers_oidc_test.spec.ts
@@ -121,6 +121,15 @@ describe("OIDC identity provider test", () => {
       masthead.checkNotificationMessage(createMapperSuccessMsg, true);
     });
 
+    it("should cancel the addition of the OIDC mapper", () => {
+      sidebarPage.goToIdentityProviders();
+      listingPage.goToItemDetails(oidcProviderName);
+      addMapperPage.goToMappersTab();
+      addMapperPage.addMapper();
+      addMapperPage.cancelNewMapper();
+      addMapperPage.shouldGoToMappersTab();
+    });
+
     it("clean up providers", () => {
       const modalUtils = new ModalUtils();
 

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/AddMapperPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/AddMapperPage.ts
@@ -19,6 +19,8 @@ export default class AddMapperPage {
   private userSessionAttribute = "attribute";
   private userSessionAttributeValue = "attribute.value";
   private newMapperSaveButton = "new-mapper-save-button";
+  private newMapperCancelButton = "new-mapper-cancel-button";
+  private mappersUrl = "/oidc/mappers";
   private regexAttributeValuesSwitch = "are.attribute.values.regex";
   private syncmodeSelectToggle = "#syncMode";
   private attributesKeyInput = '[data-testid="config.attributes[0].key"]';
@@ -48,6 +50,11 @@ export default class AddMapperPage {
 
   saveNewMapper() {
     cy.findByTestId(this.newMapperSaveButton).click();
+    return this;
+  }
+
+  cancelNewMapper() {
+    cy.findByTestId(this.newMapperCancelButton).click();
     return this;
   }
 
@@ -393,6 +400,12 @@ export default class AddMapperPage {
 
     this.addRoleToMapperForm();
     this.saveNewMapper();
+
+    return this;
+  }
+
+  shouldGoToMappersTab() {
+    cy.url().should("include", this.mappersUrl);
 
     return this;
   }

--- a/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
+++ b/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
@@ -245,6 +245,7 @@ export default function AddMapper() {
             {t("common:save")}
           </Button>
           <Button
+            data-testid="new-mapper-cancel-button"
             variant="link"
             component={(props) => (
               <Link
@@ -253,7 +254,7 @@ export default function AddMapper() {
                   realm,
                   providerId,
                   alias: alias!,
-                  tab: "settings",
+                  tab: "mappers",
                 })}
               />
             )}


### PR DESCRIPTION
## Motivation
Closes #1355 . Also added a test.

## Verification Steps
1. Go to `Identity providers` and create a new OIDC provider.
2. Select created provider and go to the `Mappers` tab and click on the `Cancel` button.
3. Verify that clicking on the `Cancel` button is taking the user to the Mappers tab.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
