### PR TITLE
Add attributes tab to realm settings

### DIFF
--- a/apps/admin-ui/src/components/key-value-form/key-value-convert-unique-keys.test.ts
+++ b/apps/admin-ui/src/components/key-value-form/key-value-convert-unique-keys.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  arrayToKeyValue,
+  keyValueToArray,
+  KeyValueType,
+} from "./key-value-convert-unique-keys";
+
+vi.mock("react");
+
+describe("Tests the convert functions for attribute input", () => {
+  it("converts empty array into form value with unique key", () => {
+    const given: KeyValueType[] = [];
+
+    //when
+    const result = keyValueToArray(given);
+
+    //then
+    expect(result).toEqual({});
+  });
+
+  it("converts array into form value with unique key", () => {
+    const given = [{ key: "theKey", value: "theValue" }];
+
+    //when
+    const result = keyValueToArray(given);
+
+    //then
+    expect(result).toEqual({ theKey: "theValue" });
+  });
+
+  it("convert only values with unique key", () => {
+    const given = [
+      { key: "theKey", value: "theValue" },
+      { key: "", value: "" },
+    ];
+
+    //when
+    const result = keyValueToArray(given);
+
+    //then
+    expect(result).toEqual({ theKey: "theValue" });
+  });
+
+  it("convert empty object to attributes with unique key", () => {
+    const given: {
+      [key: string]: string;
+    } = {};
+
+    //when
+    const result = arrayToKeyValue(given);
+
+    //then
+    expect(result).toEqual([{ key: "", value: "" }]);
+  });
+
+  it("convert object to attributes with unique key", () => {
+    const given = { one: "1", two: "2" };
+
+    //when
+    const result = arrayToKeyValue(given);
+
+    //then
+    expect(result).toEqual([
+      { key: "one", value: "1" },
+      { key: "two", value: "2" },
+      { key: "", value: "" },
+    ]);
+  });
+
+  it("convert duplicates into array values with unique key", () => {
+    const given = [
+      { key: "theKey", value: "one" },
+      { key: "theKey", value: "two" },
+    ];
+
+    //when
+    const result = keyValueToArray(given);
+
+    //then
+    expect(result).toEqual({ theKey: "two" });
+  });
+});

--- a/apps/admin-ui/src/components/key-value-form/key-value-convert-unique-keys.ts
+++ b/apps/admin-ui/src/components/key-value-form/key-value-convert-unique-keys.ts
@@ -1,0 +1,22 @@
+import { Path, PathValue } from "react-hook-form-v7";
+
+export type KeyValueType = { key: string; value: string };
+
+export function keyValueToArray(attributeArray: KeyValueType[] = []) {
+  const validAttributes = attributeArray.filter(({ key }) => key !== "");
+  const result: Record<string, string> = {};
+
+  for (const { key, value } of validAttributes) {
+    result[key] = value;
+  }
+
+  return result;
+}
+
+export function arrayToKeyValue<T>(attributes: Record<string, string> = {}) {
+  const result = Object.entries(attributes).map(([key, value]) => {
+    return { key: key, value: value };
+  });
+
+  return result.concat({ key: "", value: "" }) as PathValue<T, Path<T>>;
+}

--- a/apps/admin-ui/src/realm-settings/RealmSettingsAttributeTab.tsx
+++ b/apps/admin-ui/src/realm-settings/RealmSettingsAttributeTab.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useForm } from "react-hook-form";
+import {
+  AlertVariant,
+  PageSection,
+  PageSectionVariants,
+} from "@patternfly/react-core";
+
+import { useAlerts } from "../components/alert/Alerts";
+import {
+  AttributeForm,
+  AttributesForm,
+} from "../components/key-value-form/AttributeForm";
+import {
+  arrayToKeyValue,
+  keyValueToArray,
+} from "../components/key-value-form/key-value-convert-unique-keys";
+import { useAdminClient } from "../context/auth/AdminClient";
+import RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+
+type RealmSettingsAttributeTabProps = {
+  realm: RealmRepresentation;
+};
+
+export const RealmSettingsAttributeTab = ({
+  realm: defaultRealm,
+}: RealmSettingsAttributeTabProps) => {
+  const { t } = useTranslation("realms");
+  const { adminClient } = useAdminClient();
+  const { addAlert, addError } = useAlerts();
+  const [realm, setRealm] = useState<RealmRepresentation>(defaultRealm);
+  const form = useForm<AttributeForm>({ mode: "onChange" });
+
+  const convertAttributes = () => {
+    return arrayToKeyValue<any>(realm.attributes!);
+  };
+
+  useEffect(() => {
+    form.setValue("attributes", convertAttributes());
+  }, [realm]);
+
+  const save = async (attributeForm: AttributeForm) => {
+    try {
+      const attributes = Object.assign(
+        {},
+        keyValueToArray(attributeForm.attributes!)
+      );
+      await adminClient.realms.update(
+        { realm: realm.realm! },
+        { ...realm, attributes }
+      );
+
+      setRealm({ ...realm, attributes });
+      addAlert(t("saveSuccess"), AlertVariant.success);
+    } catch (error) {
+      addError("groups:groupUpdateError", error);
+    }
+  };
+
+  return (
+    <PageSection variant={PageSectionVariants.light}>
+      <AttributesForm
+        form={form}
+        save={save}
+        reset={() =>
+          form.reset({
+            attributes: convertAttributes(),
+          })
+        }
+      />
+    </PageSection>
+  );
+};

--- a/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
+++ b/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
@@ -51,6 +51,7 @@ import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
 import { ClientPoliciesTab, toClientPolicies } from "./routes/ClientPolicies";
 import { KeysTab } from "./keys/KeysTab";
 import type { KeyValueType } from "../components/key-value-form/key-value-convert";
+import { RealmSettingsAttributeTab } from "./RealmSettingsAttributeTab";
 
 type RealmSettingsHeaderProps = {
   onChange: (value: boolean) => void;
@@ -404,6 +405,13 @@ export const RealmSettingsTabs = ({
             {...route("user-registration")}
           >
             <UserRegistration />
+          </Tab>
+          <Tab
+            title={<TabTitleText>{t("attributes")}</TabTitleText>}
+            data-testid="rs-realm-attributes-tab"
+            {...route("attributes")}
+          >
+            <RealmSettingsAttributeTab realm={realm} />
           </Tab>
         </RoutableTabs>
       </PageSection>

--- a/apps/admin-ui/src/realm-settings/routes/RealmSettings.ts
+++ b/apps/admin-ui/src/realm-settings/routes/RealmSettings.ts
@@ -16,7 +16,8 @@ export type RealmSettingsTab =
   | "tokens"
   | "client-policies"
   | "user-profile"
-  | "user-registration";
+  | "user-registration"
+  | "attributes";
 
 export type RealmSettingsParams = {
   realm: string;


### PR DESCRIPTION
## Motivation
Add a possibility to edit realm attributes in realm settings. Fixes #3931.

## Brief Description
Added an additional tab to the realm settings. Unfortunately I was not able to use the key-value-convert, as realm attributes are represented differently on API level than other attributes (string: string instead of string: string[]). **This also leads to the effect that when adding an attribute with a key that is already present the value is just overwritten.** 

Any suggestions are welcome :)

## Verification Steps
1. Go to `Realm Settings >> Attributes`.
2. Create a new attribute with key 'test' and value 'value'.
3. Click save.
4. Verify that the new attribute is available.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
![image](https://user-images.githubusercontent.com/1793007/207964508-fc6f3579-211f-46a8-acaf-14675f01ee39.png)
