### PR TITLE
Turn protocol to required property

### DIFF
--- a/libs/keycloak-admin-client/src/defs/clientRepresentation.ts
+++ b/libs/keycloak-admin-client/src/defs/clientRepresentation.ts
@@ -3,6 +3,7 @@
  */
 import type ResourceServerRepresentation from "./resourceServerRepresentation.js";
 import type ProtocolMapperRepresentation from "./protocolMapperRepresentation.js";
+import { SSOProtocol } from "./ssoProtocols.js";
 
 export default interface ClientRepresentation {
   access?: Record<string, boolean>;
@@ -31,7 +32,7 @@ export default interface ClientRepresentation {
   notBefore?: number;
   optionalClientScopes?: string[];
   origin?: string;
-  protocol?: string;
+  protocol?: SSOProtocol;
   protocolMappers?: ProtocolMapperRepresentation[];
   publicClient?: boolean;
   redirectUris?: string[];

--- a/libs/keycloak-admin-client/src/defs/clientScopeRepresentation.ts
+++ b/libs/keycloak-admin-client/src/defs/clientScopeRepresentation.ts
@@ -2,12 +2,23 @@
  * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientscoperepresentation
  */
 import type ProtocolMapperRepresentation from "./protocolMapperRepresentation.js";
+import { SSOProtocol } from "./ssoProtocols.js";
 
 export default interface ClientScopeRepresentation {
   attributes?: Record<string, any>;
   description?: string;
   id?: string;
   name?: string;
-  protocol?: string;
+  protocol?: SSOProtocol;
   protocolMappers?: ProtocolMapperRepresentation[];
+}
+
+/**
+ * This interace is used to cover the create function of ClientScope.
+ * Cause UPDATET should be just send the modifyed data, protocol could not be mandatory in that case!
+ */
+export interface ClientScopeCreateRepresentation
+  extends ClientScopeRepresentation {
+  protocol: SSOProtocol;
+  name: string;
 }

--- a/libs/keycloak-admin-client/src/defs/protocolMapperRepresentation.ts
+++ b/libs/keycloak-admin-client/src/defs/protocolMapperRepresentation.ts
@@ -2,10 +2,12 @@
  * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_protocolmapperrepresentation
  */
 
+import { SSOProtocol } from "./ssoProtocols.js";
+
 export default interface ProtocolMapperRepresentation {
   config?: Record<string, any>;
   id?: string;
   name?: string;
-  protocol?: string;
+  protocol?: SSOProtocol;
   protocolMapper?: string;
 }

--- a/libs/keycloak-admin-client/src/defs/serverInfoRepesentation.ts
+++ b/libs/keycloak-admin-client/src/defs/serverInfoRepesentation.ts
@@ -3,6 +3,7 @@ import type { ConfigPropertyRepresentation } from "./configPropertyRepresentatio
 import type PasswordPolicyTypeRepresentation from "./passwordPolicyTypeRepresentation.js";
 import type ProfileInfoRepresentation from "./profileInfoRepresentation.js";
 import type ProtocolMapperRepresentation from "./protocolMapperRepresentation.js";
+import { SSOProtocol } from "./ssoProtocols.js";
 import type SystemInfoRepresentation from "./systemInfoRepersantation.js";
 
 /**
@@ -43,7 +44,7 @@ export interface ProviderRepresentation {
 
 export interface ClientInstallationRepresentation {
   id: string;
-  protocol: string;
+  protocol: SSOProtocol;
   downloadOnly: boolean;
   displayType: string;
   helpText: string;

--- a/libs/keycloak-admin-client/src/defs/ssoProtocols.ts
+++ b/libs/keycloak-admin-client/src/defs/ssoProtocols.ts
@@ -1,0 +1,21 @@
+/**
+ * Based upon the keycloak documentation could be found here
+ * https://www.keycloak.org/docs/latest/server_admin/#sso-protocols
+ * or here
+ * https://wjw465150.gitbooks.io/keycloak-documentation/content/server_admin/topics/sso-protocols.html
+ * there are actually three different SSO Protocols named and implemented
+ */
+export const SSOProtocol = {
+  "openid-connect": "openid-connect",
+  saml: "saml",
+  "docker-v2": "docker-v2",
+};
+
+/**
+ * This 'complex' reconstruction of type by keyof typeof is actually equal to
+ * export type SSOProtocol = "openid-connect" | "saml" | "docker-v2";
+ * In case SSO Protocol will be modified, you do not have to touch this type configuration by using this setup.
+ * This is inline with the TypeScript concept by replaceing an enum with an const object:
+ * Object vs. Enums - https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums
+ */
+export type SSOProtocol = typeof SSOProtocol[keyof typeof SSOProtocol];

--- a/libs/keycloak-admin-client/src/resources/clientScopes.ts
+++ b/libs/keycloak-admin-client/src/resources/clientScopes.ts
@@ -4,6 +4,8 @@ import type { KeycloakAdminClient } from "../client.js";
 import type ProtocolMapperRepresentation from "../defs/protocolMapperRepresentation.js";
 import type MappingsRepresentation from "../defs/mappingsRepresentation.js";
 import type RoleRepresentation from "../defs/roleRepresentation.js";
+import { SSOProtocol } from "../defs/ssoProtocols.js";
+import { ClientScopeCreateRepresentation } from "../defs/clientScopeRepresentation.js";
 
 export class ClientScopes extends Resource<{ realm?: string }> {
   public find = this.makeRequest<{}, ClientScopeRepresentation[]>({
@@ -11,7 +13,10 @@ export class ClientScopes extends Resource<{ realm?: string }> {
     path: "/client-scopes",
   });
 
-  public create = this.makeRequest<ClientScopeRepresentation, { id: string }>({
+  public create = this.makeRequest<
+    ClientScopeCreateRepresentation,
+    { id: string }
+  >({
     method: "POST",
     path: "/client-scopes",
     returnResourceIdInLocationHeader: { field: "id" },
@@ -143,7 +148,7 @@ export class ClientScopes extends Resource<{ realm?: string }> {
   });
 
   public findProtocolMappersByProtocol = this.makeRequest<
-    { id: string; protocol: string },
+    { id: string; protocol: SSOProtocol },
     ProtocolMapperRepresentation[]
   >({
     method: "GET",

--- a/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/libs/keycloak-admin-client/src/resources/clients.ts
@@ -16,6 +16,7 @@ import type ResourceRepresentation from "../defs/resourceRepresentation.js";
 import type ResourceServerRepresentation from "../defs/resourceServerRepresentation.js";
 import type RoleRepresentation from "../defs/roleRepresentation.js";
 import type ScopeRepresentation from "../defs/scopeRepresentation.js";
+import { SSOProtocol } from "../defs/ssoProtocols.js";
 import type UserRepresentation from "../defs/userRepresentation.js";
 import type UserSessionRepresentation from "../defs/userSessionRepresentation.js";
 import Resource from "./resource.js";
@@ -297,7 +298,7 @@ export class Clients extends Resource<{ realm?: string }> {
   });
 
   public findProtocolMappersByProtocol = this.makeRequest<
-    { id: string; protocol: string },
+    { id: string; protocol: SSOProtocol },
     ProtocolMapperRepresentation[]
   >({
     method: "GET",

--- a/libs/keycloak-admin-client/src/utils/constants.ts
+++ b/libs/keycloak-admin-client/src/utils/constants.ts
@@ -1,3 +1,3 @@
-export const defaultBaseUrl = "http://127.0.0.1:8180";
+export const defaultBaseUrl = "http://127.0.0.1:8080";
 
 export const defaultRealm = "master";

--- a/libs/keycloak-admin-client/test/clientScopes.spec.ts
+++ b/libs/keycloak-admin-client/test/clientScopes.spec.ts
@@ -5,6 +5,7 @@ import type ClientRepresentation from "../src/defs/clientRepresentation.js";
 import type ClientScopeRepresentation from "../src/defs/clientScopeRepresentation.js";
 import type ProtocolMapperRepresentation from "../src/defs/protocolMapperRepresentation.js";
 import { credentials } from "./constants.js";
+import { SSOProtocol } from "../src/defs/ssoProtocols.js";
 
 const expect = chai.expect;
 
@@ -23,6 +24,7 @@ describe("Client Scopes", () => {
     currentClientScopeName = "best-of-the-bests-scope";
     await kcAdminClient.clientScopes.create({
       name: currentClientScopeName,
+      protocol: SSOProtocol["openid-connect"],
     });
     currentClientScope = (await kcAdminClient.clientScopes.findOneByName({
       name: currentClientScopeName,
@@ -75,6 +77,7 @@ describe("Client Scopes", () => {
 
     await kcAdminClient.clientScopes.create({
       name: currentClientScopeName,
+      protocol: SSOProtocol["openid-connect"],
     });
 
     const scope = (await kcAdminClient.clientScopes.findOneByName({
@@ -82,6 +85,7 @@ describe("Client Scopes", () => {
     }))!;
     expect(scope).to.be.ok;
     expect(scope.name).to.equal(currentClientScopeName);
+    expect(scope.protocol).to.equal(SSOProtocol["openid-connect"]);
   });
 
   it("create client scope and return id", async () => {
@@ -96,6 +100,7 @@ describe("Client Scopes", () => {
 
     const { id } = await kcAdminClient.clientScopes.create({
       name: currentClientScopeName,
+      protocol: SSOProtocol["openid-connect"],
     });
 
     const scope = (await kcAdminClient.clientScopes.findOne({
@@ -103,6 +108,7 @@ describe("Client Scopes", () => {
     }))!;
     expect(scope).to.be.ok;
     expect(scope.name).to.equal(currentClientScopeName);
+    expect(scope.protocol).to.equal(SSOProtocol["openid-connect"]);
   });
 
   it("find scope by id", async () => {
@@ -256,7 +262,7 @@ describe("Client Scopes", () => {
     beforeEach(() => {
       dummyMapper = {
         name: "mapping-maps-mapper",
-        protocol: "openid-connect",
+        protocol: SSOProtocol["openid-connect"],
         protocolMapper: "oidc-audience-mapper",
       };
     });

--- a/libs/keycloak-admin-client/test/clients.spec.ts
+++ b/libs/keycloak-admin-client/test/clients.spec.ts
@@ -11,6 +11,8 @@ import type ResourceRepresentation from "../src/defs/resourceRepresentation.js";
 import type ScopeRepresentation from "../src/defs/scopeRepresentation.js";
 import type UserRepresentation from "../src/defs/userRepresentation.js";
 import { credentials } from "./constants.js";
+import { ClientScopeCreateRepresentation } from "../src/defs/clientScopeRepresentation.js";
+import { SSOProtocol } from "../src/defs/ssoProtocols.js";
 
 const expect = chai.expect;
 
@@ -274,11 +276,13 @@ describe("Clients", () => {
       dummyClientScope = {
         name: "does-anyone-read-this",
         description: "Oh - seems like you are reading  Hey there!",
-        protocol: "openid-connect",
+        protocol: SSOProtocol["openid-connect"],
       };
 
       // setup dummy client scope
-      await kcAdminClient.clientScopes.create(dummyClientScope);
+      await kcAdminClient.clientScopes.create(
+        dummyClientScope as ClientScopeCreateRepresentation
+      );
       currentClientScope = (await kcAdminClient.clientScopes.findOneByName({
         name: dummyClientScope.name!,
       }))!;
@@ -368,11 +372,13 @@ describe("Clients", () => {
       dummyClientScope = {
         name: "i-hope-your-well",
         description: "Everyone has that one friend.",
-        protocol: "openid-connect",
+        protocol: SSOProtocol["openid-connect"],
       };
 
       // setup dummy client scope
-      await kcAdminClient.clientScopes.create(dummyClientScope);
+      await kcAdminClient.clientScopes.create(
+        dummyClientScope as ClientScopeCreateRepresentation
+      );
       currentClientScope = (await kcAdminClient.clientScopes.findOneByName({
         name: dummyClientScope.name!,
       }))!;
@@ -459,7 +465,7 @@ describe("Clients", () => {
     beforeEach(() => {
       dummyMapper = {
         name: "become-a-farmer",
-        protocol: "openid-connect",
+        protocol: SSOProtocol["openid-connect"],
         protocolMapper: "oidc-role-name-mapper",
         config: {
           role: "admin",

--- a/libs/keycloak-admin-client/test/constants.ts
+++ b/libs/keycloak-admin-client/test/constants.ts
@@ -2,7 +2,7 @@ import type { Credentials } from "../src/utils/auth.js";
 
 export const credentials: Credentials = {
   username: "admin",
-  password: "admin",
+  password: "change_me",
   grantType: "password",
   clientId: "admin-cli",
 };


### PR DESCRIPTION
## Motivation
When using the API, it is not exactly clear which values are mandatory when creating the individual entities. Mandatory does not refer to the acceptance or rejection by the REST API endpoint but to the functioning of the Admin UI. 
If a ClientScope is created without a protocol, the entire Admin UI delivered with the keycloak breaks down. Errors also appear internally on the console. 

Accordingly, the developers should be given the possible protocols on the one hand, and these values should also be validated and requested on the client side.


## Brief Description
Including a formal TyeScript definition based on th SSO Protocol types mentioned within the Keycloak documentation itself!

## Verification Steps
Create a ClientScope within Admin CLI, and validate admin console ui on your Keycloak instance. It should be up and running and not broken :) 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated  **( Network issue with Identity provider but same issue is on the main branch!)**

## Additional Notes

Unfortunately, it is a problem to use the same interface for CREATE and UPDATE. In the case of CREATE, protocol is mandatory, but in the case of UPDATE, only really modified values should be sent. As a result, protocol must not be required as a value. Therefore, two different interfaces are needed.