### PR TITLE
add openid as default scope and add option to set custom scopes

### DIFF
--- a/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/libs/keycloak-admin-client/src/utils/auth.ts
@@ -61,9 +61,7 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
     grant_type: credentials.grantType,
     client_id: credentials.clientId,
     totp: credentials.totp,
-    ...(credentials.offlineToken
-      ? { scope: "offline_access" }
-      : { scope: "openid" }),
+    ...(credentials.offlineToken ? { scope: "offline_access" } : {}),
     ...(credentials.scopes ? { scope: credentials.scopes.join(" ") } : {}),
     ...(credentials.refreshToken
       ? {

--- a/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/libs/keycloak-admin-client/src/utils/auth.ts
@@ -33,6 +33,7 @@ export interface TokenResponseRaw {
   not_before_policy: number;
   session_state: string;
   scope: string;
+  id_token?: string;
 }
 
 export interface TokenResponse {
@@ -44,6 +45,7 @@ export interface TokenResponse {
   notBeforePolicy: number;
   sessionState: string;
   scope: string;
+  idToken?: string;
 }
 
 export const getToken = async (settings: Settings): Promise<TokenResponse> => {

--- a/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/libs/keycloak-admin-client/src/utils/auth.ts
@@ -14,6 +14,7 @@ export interface Credentials {
   totp?: string;
   offlineToken?: boolean;
   refreshToken?: string;
+  scopes?: string[];
 }
 
 export interface Settings {
@@ -60,7 +61,10 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
     grant_type: credentials.grantType,
     client_id: credentials.clientId,
     totp: credentials.totp,
-    ...(credentials.offlineToken ? { scope: "offline_access" } : {}),
+    ...(credentials.offlineToken
+      ? { scope: "offline_access" }
+      : { scope: "openid" }),
+    ...(credentials.scopes ? { scope: credentials.scopes.join(" ") } : {}),
     ...(credentials.refreshToken
       ? {
           refresh_token: credentials.refreshToken,

--- a/libs/keycloak-admin-client/test/auth.spec.ts
+++ b/libs/keycloak-admin-client/test/auth.spec.ts
@@ -20,7 +20,6 @@ describe("Authorization", () => {
       "sessionState",
       "scope"
     );
-    expect(data.scope).to.equal("openid");
   });
 
   it("should get token from local keycloak with custom scope", async () => {
@@ -39,8 +38,10 @@ describe("Authorization", () => {
       "tokenType",
       "notBeforePolicy",
       "sessionState",
-      "scope"
+      "scope",
+      "idToken"
     );
-    expect(data.scope).to.equal("openid profile");
+
+    expect(data.scope).to.equal("openid profile email");
   });
 });

--- a/libs/keycloak-admin-client/test/auth.spec.ts
+++ b/libs/keycloak-admin-client/test/auth.spec.ts
@@ -20,5 +20,27 @@ describe("Authorization", () => {
       "sessionState",
       "scope"
     );
+    expect(data.scope).to.equal("openid");
+  });
+
+  it("should get token from local keycloak with custom scope", async () => {
+    const data = await getToken({
+      credentials: {
+        ...credentials,
+        scopes: ["openid", "profile"],
+      },
+    });
+
+    expect(data).to.have.all.keys(
+      "accessToken",
+      "expiresIn",
+      "refreshExpiresIn",
+      "refreshToken",
+      "tokenType",
+      "notBeforePolicy",
+      "sessionState",
+      "scope"
+    );
+    expect(data.scope).to.equal("openid profile");
   });
 });


### PR DESCRIPTION
## Motivation
Since the release of keycloak 20.0.0 it is required to specify the scope when authenticating. This is easily discovered when calling the /userinfo endpoint in keycloak with an auth token that is created without the scope.
https://www.keycloak.org/docs/latest/upgrading/#userinfo-endpoint-changes

## Brief Description
I have added a default scope as "openid" to solve above problem. 
I have also added an optional parameter for users who wish to set their own scope.

## Verification Steps
1. get an auth token by calling
```
const keycloakAdmin = new KeycloakAdmin({<some settings>})
keycloakAdmin.auth(authInfo)
```
2. Use the accessToken created above and call the `protocol/openid-connect/userinfo` endpoint.3. 
3. Before this PR it results in a 403.

## Checklist:

- [x] Code has been tested locally by PR requester
- [N/A] User-visible strings are using the react-i18next framework (useTranslation)
- [N/A] Help has been implemented
- [N/A] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

