### PR TITLE
Identity provider link is not displayed when display name is empty

### DIFF
--- a/apps/admin-ui/src/identity-providers/IdentityProvidersSection.tsx
+++ b/apps/admin-ui/src/identity-providers/IdentityProvidersSection.tsx
@@ -84,7 +84,7 @@ export default function IdentityProvidersSection() {
         tab: "settings",
       })}
     >
-      {identityProvider.displayName ?? identityProvider.alias}
+      {identityProvider.displayName || identityProvider.alias}
       {!identityProvider.enabled && (
         <Badge
           key={`${identityProvider.providerId}-disabled`}


### PR DESCRIPTION
Closes #4111 