### PR TITLE
Use React Router v6 for the routable tabs

### DIFF
--- a/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -299,6 +299,20 @@ export default function DetailSettings() {
     return components;
   };
 
+  const toTab = (tab: IdentityProviderTab) =>
+    toIdentityProvider({
+      realm,
+      alias,
+      providerId,
+      tab,
+    });
+
+  const useTab = (tab: IdentityProviderTab) => useRoutableTab(toTab(tab));
+
+  const settingsTab = useTab("settings");
+  const mappersTab = useTab("mappers");
+  const permissionsTab = useTab("permissions");
+
   const sections = [
     {
       title: t("generalSettings"),


### PR DESCRIPTION
Converts the routable tabs code to use the latest version of React Router. This is one of the last pieces needed finish the migration to the new React Router.