### PR TITLE
Add `clear-data` script to Keycloak server

### DIFF
--- a/apps/keycloak-server/package.json
+++ b/apps/keycloak-server/package.json
@@ -2,7 +2,8 @@
   "name": "keycloak-server",
   "scripts": {
     "start": "./scripts/start-server.mjs",
-    "import-client": "wireit"
+    "import-client": "wireit",
+    "clear-data": "rm -r ./server/data"
   },
   "wireit": {
     "import-client": {


### PR DESCRIPTION
Adds a convenient  `clear-data` script to the Keycloak server. This removes any stored information from a previously downloaded Keycloak server, allowing you to start with a clean database.