### PR TITLE
Client assertion signature configuration of identity broker is missing on new security admin console

### DIFF
--- a/apps/admin-ui/cypress/WRITING_TESTS.md
+++ b/apps/admin-ui/cypress/WRITING_TESTS.md
@@ -84,4 +84,4 @@ If there were no calls and you still get this error, try using `{force: true}`, 
 
 * [Moises document](https://docs.google.com/document/d/11sm1IpEvVLHO59JEVmwgNOUD0zoP4YMvInIU4v5iVNk/edit)
 * [Cypress blog do not get too detached](https://www.cypress.io/blog/2020/07/22/do-not-get-too-detached/)
-* [See the clients_test.spec as an example](./cypress/integration/clients_test.spec.ts)
+* [See the clients_test.spec as an example](./cypress/e2e/clients_test.spec.ts)

--- a/apps/admin-ui/cypress/e2e/identity_providers_oidc_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/identity_providers_oidc_test.spec.ts
@@ -8,6 +8,7 @@ import ModalUtils from "../support/util/ModalUtils";
 import AddMapperPage from "../support/pages/admin-ui/manage/identity_providers/AddMapperPage";
 import ProviderBaseGeneralSettingsPage from "../support/pages/admin-ui/manage/identity_providers/ProviderBaseGeneralSettingsPage";
 import ProviderBaseAdvancedSettingsPage, {
+  ClientAssertionSigningAlg,
   ClientAuthentication,
   PromptSelect,
 } from "../support/pages/admin-ui/manage/identity_providers/ProviderBaseAdvancedSettingsPage";
@@ -91,6 +92,10 @@ describe("OIDC identity provider test", () => {
       providerBaseAdvancedSettingsPage.assertOIDCClientAuthentication(
         ClientAuthentication.post
       );
+      //Client assertion signature algorithm
+      Object.entries(ClientAssertionSigningAlg).forEach(([, value]) => {
+        providerBaseAdvancedSettingsPage.assertOIDCClientAuthSignAlg(value);
+      });
       //OIDC Advanced Settings
       providerBaseAdvancedSettingsPage.assertOIDCSettingsAdvancedSwitches();
       providerBaseAdvancedSettingsPage.selectPromptOption(PromptSelect.none);

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/ProviderBaseAdvancedSettingsPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/identity_providers/ProviderBaseAdvancedSettingsPage.ts
@@ -35,6 +35,22 @@ export enum ClientAuthentication {
   jwtPrivKey = "Client secret sent as post",
 }
 
+export enum ClientAssertionSigningAlg {
+  algorithmNotSpecified = "Algorithm not specified",
+  es256 = "ES256",
+  es384 = "ES384",
+  es512 = "ES512",
+  hs256 = "HS256",
+  hs384 = "HS384",
+  hs512 = "HS512",
+  ps256 = "PS256",
+  ps384 = "PS384",
+  ps512 = "PS512",
+  rs256 = "RS256",
+  rs384 = "RS384",
+  rs512 = "RS512",
+}
+
 export default class ProviderBaseGeneralSettingsPage extends PageObject {
   private scopesInput = "#scopes";
   private storeTokensSwitch = "#storeTokens";
@@ -63,6 +79,7 @@ export default class ProviderBaseGeneralSettingsPage extends PageObject {
   private pkceSwitch = "#pkceEnabled";
   private pkceMethod = "#pkceMethod";
   private clientAuth = "#clientAuthentication";
+  private clientAssertionSigningAlg = "#clientAssertionSigningAlg";
 
   public clickSaveBtn() {
     cy.findByTestId(this.saveBtn).click();
@@ -126,6 +143,17 @@ export default class ProviderBaseGeneralSettingsPage extends PageObject {
     super.clickSelectMenuItem(
       loginFlowOption,
       cy.get(".pf-c-select__menu-item").contains(loginFlowOption)
+    );
+    return this;
+  }
+
+  public selectClientAssertSignAlg(
+    clientAssertionSigningAlg: ClientAssertionSigningAlg
+  ) {
+    cy.get(this.clientAssertionSigningAlg).click();
+    super.clickSelectMenuItem(
+      clientAssertionSigningAlg,
+      cy.get(".pf-c-select__menu-item").contains(clientAssertionSigningAlg)
     );
     return this;
   }
@@ -221,6 +249,16 @@ export default class ProviderBaseGeneralSettingsPage extends PageObject {
     return this;
   }
 
+  public assertClientAssertSigAlgSelectOptionEqual(
+    clientAssertionSigningAlg: ClientAssertionSigningAlg
+  ) {
+    cy.get(this.clientAssertionSigningAlg).should(
+      "have.text",
+      clientAssertionSigningAlg
+    );
+    return this;
+  }
+
   public assertOIDCUrl(url: string) {
     cy.findByTestId("jump-link-openid-connect-settings").click();
     cy.findByTestId(url + "Url")
@@ -272,6 +310,16 @@ export default class ProviderBaseGeneralSettingsPage extends PageObject {
       .click()
       .get(".pf-c-select__menu-item")
       .contains(option)
+      .click();
+    return this;
+  }
+
+  public assertOIDCClientAuthSignAlg(alg: string) {
+    cy.findByTestId("jump-link-openid-connect-settings").click();
+    cy.get(this.clientAssertionSigningAlg)
+      .click()
+      .get(".pf-c-select__menu-item")
+      .contains(alg)
       .click();
     return this;
   }
@@ -331,6 +379,9 @@ export default class ProviderBaseGeneralSettingsPage extends PageObject {
     );
     this.assertPostLoginFlowSelectOptionEqual(LoginFlowOption.none);
     this.assertSyncModeSelectOptionEqual(SyncModeOption.import);
+    this.assertClientAssertSigAlgSelectOptionEqual(
+      ClientAssertionSigningAlg.algorithmNotSpecified
+    );
     return this;
   }
 }

--- a/apps/admin-ui/public/resources/en/identity-providers-help.json
+++ b/apps/admin-ui/public/resources/en/identity-providers-help.json
@@ -30,6 +30,7 @@
   "attributeConsumingServiceName": "Name of the Attribute Consuming Service profile to advertise in the SP metadata.",
   "forwardParameters": "Non OpenID Connect/OAuth standard query parameters to be forwarded to external IDP from the initial application request to Authorization Endpoint. Multiple parameters can be entered, separated by comma (,).",
   "clientAuthentication": "The client authentication method (cfr. https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication). In case of JWT signed with private key, the realm private key is used.",
+  "clientAssertionSigningAlg": "Signature algorithm to create JWT assertion as client authentication. In the case of JWT signed with private key or Client secret as jwt, it is required. If no algorithm is specified, the following algorithm is adapted. RS256 is adapted in the case of JWT signed with private key. HS256 is adapted in the case of Client secret as jwt.",
   "storeTokens": "Enable/disable if tokens must be stored after authenticating users.",
   "storedTokensReadable": "Enable/disable if new users can read any stored tokens. This assigns the broker.read-token role.",
   "trustEmail": "If enabled, email provided by this provider is not verified even if verification is enabled for the realm.",

--- a/apps/admin-ui/public/resources/en/identity-providers.json
+++ b/apps/admin-ui/public/resources/en/identity-providers.json
@@ -117,6 +117,8 @@
     "client_secret_jwt": "Client secret as jwt",
     "private_key_jwt": "JWT signed with private key"
   },
+  "clientAssertionSigningAlg": "Client asserion signature algorithm",
+  "algorithmNotSpecified": "Algorithm not specified",
   "acceptsPromptNone": "Accepts prompt=none forward from client",
   "validateSignature": "Validate Signatures",
   "useJwksUrl": "Use JWKS URL",

--- a/apps/admin-ui/public/resources/ja/identity-providers-help.json
+++ b/apps/admin-ui/public/resources/ja/identity-providers-help.json
@@ -20,6 +20,7 @@
   "allowedClockSkew": "アイデンティティー・プロバイダーのトークンの検証時に許容されるクロックスキュー（秒単位）。デフォルト値は0です。",
   "forwardParameters": "最初のアプリケーションへのリクエストから取得し、外部IDPの認可エンドポイントへ転送されるOpenID Connect/OAuth標準以外のクエリー・パラメーター。複数のパラメーターをカンマ（,）で区切って入力できます。",
   "clientAuthentication": "クライアント認証方法（参照：https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication）。秘密鍵で署名されたJWTの場合、レルム秘密鍵が使用されます。",
+  "clientAssertionSigningAlg": "クライアント認証でJWTアサーションを利用するときの署名アルゴリズム。クライアント認証が 秘密鍵で署名されたJWT もしくは JWTでクライアント・シークレット の場合に設定します。アルゴリズムの指定をしなかった場合、 秘密鍵で署名されたJWT ではRS256 JWTでクライアント・シークレット ではHS256のアルゴリズムが使用されます。",
   "storeTokens": "ユーザー認証後のトークン格納の有効/無効を設定します。",
   "storedTokensReadable": "新しいユーザーが格納されたトークンを読み取り可能かどうかの有効/無効設定です。broker.read-tokenロールをアサインします。",
   "trustEmail": "有効とした場合は、このレルムでEメールの確認が有効となっている場合でも、このプロバイダーが提供するEメールは確認されなくなります。",

--- a/apps/admin-ui/public/resources/ja/identity-providers.json
+++ b/apps/admin-ui/public/resources/ja/identity-providers.json
@@ -39,11 +39,13 @@
   },
   "clientAuthentication": "クライアント認証",
   "clientAuthentications": {
-    "clientAuth_post": "POSTで送信されたクライアント・シークレット",
-    "clientAuth_basic": "基本認証で送信されたクライアント・シークレット",
-    "clientAuth_secret_jwt": "JWTでクライアント・シークレット",
-    "clientAuth_privatekey_jwt": "秘密鍵で署名されたJWT"
+    "client_secret_post": "POSTで送信されたクライアント・シークレット",
+    "client_secret_basic": "基本認証で送信されたクライアント・シークレット",
+    "client_secret_jwt": "JWTでクライアント・シークレット",
+    "private_key_jwt": "秘密鍵で署名されたJWT"
   },
+  "clientAssertionSigningAlg": "クライアントアサーション署名アルゴリズム",
+  "algorithmNotSpecified": "アルゴリズムの指定なし",
   "acceptsPromptNone": "クライアントから転送されるprompt=noneを受け入れる",
   "validateSignature": "署名検証",
   "useJwksUrl": "JWKS URLの使用",

--- a/apps/admin-ui/src/identity-providers/add/OIDCAuthentication.tsx
+++ b/apps/admin-ui/src/identity-providers/add/OIDCAuthentication.tsx
@@ -10,6 +10,8 @@ import { useTranslation } from "react-i18next";
 
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { ClientIdSecret } from "../component/ClientIdSecret";
+import { sortProviders } from "../../util";
+import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 
 const clientAuthentications = [
   "client_secret_post",
@@ -19,10 +21,12 @@ const clientAuthentications = [
 ];
 
 export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {
+  const providers = useServerInfo().providers!.clientSignature.providers;
   const { t } = useTranslation("identity-providers");
 
   const { control } = useFormContext();
   const [openClientAuth, setOpenClientAuth] = useState(false);
+  const [openClientAuthSigAlg, setOpenClientAuthSigAlg] = useState(false);
 
   const clientAuthMethod = useWatch({
     control: control,
@@ -76,6 +80,49 @@ export const OIDCAuthentication = ({ create = true }: { create?: boolean }) => {
         secretRequired={clientAuthMethod !== "private_key_jwt"}
         create={create}
       />
+      <FormGroup
+        label={t("clientAssertionSigningAlg")}
+        labelIcon={
+          <HelpItem
+            helpText="identity-providers-help:clientAssertionSigningAlg"
+            fieldLabelId="identity-providers:clientAssertionSigningAlg"
+          />
+        }
+        fieldId="clientAssertionSigningAlg"
+      >
+        <Controller
+          name="config.clientAssertionSigningAlg"
+          defaultValue=""
+          control={control}
+          render={({ field }) => (
+            <Select
+              maxHeight={200}
+              toggleId="clientAssertionSigningAlg"
+              onToggle={() => setOpenClientAuthSigAlg(!openClientAuthSigAlg)}
+              onSelect={(_, value) => {
+                field.onChange(value.toString());
+                setOpenClientAuthSigAlg(false);
+              }}
+              selections={field.value || t("algorithmNotSpecified")}
+              variant={SelectVariant.single}
+              isOpen={openClientAuthSigAlg}
+            >
+              {[
+                <SelectOption selected={field.value === ""} key="" value="">
+                  {t("algorithmNotSpecified")}
+                </SelectOption>,
+                ...sortProviders(providers).map((option) => (
+                  <SelectOption
+                    selected={option === field.value}
+                    key={option}
+                    value={option}
+                  />
+                )),
+              ]}
+            </Select>
+          )}
+        />
+      </FormGroup>
     </>
   );
 };


### PR DESCRIPTION

## Motivation
keycloak/keycloak#14021

## Brief Description
Closes #4144 

## Verification Steps
No response

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
I changed this one along with WRITING_TEST.md.
