### PR TITLE
Refactor realms & client roles to React Router v6

### DIFF
--- a/apps/admin-ui/src/clients/routes/ClientRole.ts
+++ b/apps/admin-ui/src/clients/routes/ClientRole.ts
@@ -17,11 +17,11 @@ export type ClientRoleParams = {
 };
 
 export const ClientRoleRoute: RouteDef = {
-  path: "/:realm/clients/:clientId/roles/:id/:tab",
+  path: "/:realm/clients/:clientId/roles/:id/:tab" as const,
   component: lazy(() => import("../../realm-roles/RealmRoleTabs")),
   breadcrumb: (t) => t("roles:roleDetails"),
   access: "view-realm",
-};
+} satisfies RouteDef;
 
 export const toClientRole = (params: ClientRoleParams): Partial<Path> => ({
   pathname: generatePath(ClientRoleRoute.path, params),


### PR DESCRIPTION
Converts the realm and client roles code to use React Router v6. Also replaces dynamically built paths with route functions.