### PR TITLE
Reduce excessive re-renders for realm & client roles tab

### DIFF
--- a/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -535,9 +535,7 @@ describe("Clients test", () => {
     });
 
     it("Should add attribute to client role", () => {
-      cy.intercept("/admin/realms/master/roles-by-id/*").as("load");
       commonPage.tableUtils().clickRowItemLink(itemId);
-      cy.wait("@load");
       rolesTab.goToAttributesTab();
       attributesTab
         .addAttribute("crud_attribute_key", "crud_attribute_value")
@@ -549,9 +547,7 @@ describe("Clients test", () => {
     });
 
     it("Should delete attribute from client role", () => {
-      cy.intercept("/admin/realms/master/roles-by-id/*").as("load");
       commonPage.tableUtils().clickRowItemLink(itemId);
-      cy.wait("@load");
       rolesTab.goToAttributesTab();
       attributesTab.deleteAttribute(1);
       commonPage

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/clients/ClientRolesTab.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/clients/ClientRolesTab.ts
@@ -19,9 +19,7 @@ export default class ClientRolesTab extends CommonPage {
   }
 
   goToAttributesTab() {
-    cy.intercept("/admin/realms/master/roles-by-id/*").as("load");
     this.tabUtils().clickTab(ClientRolesTabItems.Attributes);
-    cy.wait("@load");
     return this;
   }
 
@@ -36,9 +34,7 @@ export default class ClientRolesTab extends CommonPage {
   }
 
   goToAssociatedRolesTab() {
-    cy.intercept("/admin/realms/master/roles-by-id/*").as("load");
     cy.get(this.associatedRolesTab).click();
-    cy.wait("@load");
     return this;
   }
 

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_roles/CreateRealmRolePage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_roles/CreateRealmRolePage.ts
@@ -63,9 +63,7 @@ class CreateRealmRolePage {
   }
 
   goToAttributesTab() {
-    cy.intercept("admin/realms/master/roles-by-id/*").as("load");
     cy.get(".kc-attributes-tab > button").click();
-    cy.wait(["@load", "@load"]);
     return this;
   }
 }

--- a/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
+++ b/apps/admin-ui/src/realm-roles/RealmRoleTabs.tsx
@@ -100,14 +100,11 @@ export default function RealmRoleTabs() {
 
       const convertedRole = convert(role);
 
+      reset(convertedRole);
       setRealm(realm);
       setRole(convertedRole);
-
-      Object.entries(convertedRole).map((entry) => {
-        setValue(entry[0], entry[1]);
-      });
     },
-    [key, url]
+    [key]
   );
 
   const onSubmit: SubmitHandler<AttributeForm> = async (formValues) => {


### PR DESCRIPTION
Fixes a bug introduced by #1838 where the realm & client roles tab would create an excessive amount of requests and subsequently re-renders. This was caused by providing the current URL as a dependency to `useFetch()` which would trigger a request every time the tab was changed, even when such a fetch was not needed.

This also removes a bunch of request intercepts from the Cypress tests, which were added to stabilize the tests. Presumably this instability was actually caused by the changes made in #1838 as well.