### PR TITLE
small fix to also add the group when it's used

### DIFF
--- a/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -203,7 +203,7 @@ export default function NewAttributeSettings() {
           profileConfig.isRequired
             ? { required: profileConfig.required }
             : undefined,
-          profileConfig.group ? { group: profileConfig.group } : undefined
+          profileConfig.group ? { group: profileConfig.group } : { group: null }
         );
       });
 

--- a/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
+++ b/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
@@ -53,7 +53,7 @@ export const AttributesTab = () => {
     config?.attributes!.splice(newIndex, 0, movedAttribute);
 
     save(
-      { attributes: config?.attributes! },
+      { attributes: config?.attributes!, groups: config?.groups },
       {
         successMessageKey: "realm-settings:updatedUserProfileSuccess",
         errorMessageKey: "realm-settings:updatedUserProfileError",
@@ -74,7 +74,7 @@ export const AttributesTab = () => {
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
       save(
-        { attributes: updatedAttributes! },
+        { attributes: updatedAttributes!, groups: config?.groups },
         {
           successMessageKey: "realm-settings:deleteAttributeSuccess",
           errorMessageKey: "realm-settings:deleteAttributeError",


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
When groups are used for the user profile, but they are not passed when updating, then we get an error from the server.
This PR addresses this.

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
