### PR TITLE
Allow add/remove user with only query-users role.

### DIFF
--- a/apps/admin-ui/src/user/UsersSection.tsx
+++ b/apps/admin-ui/src/user/UsersSection.tsx
@@ -74,7 +74,12 @@ export default function UsersSection() {
   const refresh = () => setKey(key + 1);
 
   const { hasAccess } = useAccess();
-  const isManager = hasAccess("manage-users");
+
+  // Only needs query-users access to attempt add/delete of users.
+  // This is because the user could have fine-grained access to users
+  // of a group.  There is no way to know this without searching the
+  // permissions of every group.
+  const isManager = hasAccess("query-users");
 
   useFetch(
     async () => {


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-ui/issues/3965

## Brief Description
Relies on recent back end change. See https://github.com/keycloak/keycloak/pull/15967

## Verification Steps
See https://github.com/keycloak/keycloak-ui/issues/3965

Simpler way than what is in the issue is to grant permissions with a user policy instead of a group policy.
