### PR TITLE
Experiment to fix flaky predefined mapper test.

### DIFF
--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/clients/client_details/DedicatedScopesMappersTab.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/clients/client_details/DedicatedScopesMappersTab.ts
@@ -29,9 +29,7 @@ export default class DedicatedScopesMappersTab extends CommonPage {
 
   addPredefinedMapper() {
     this.emptyState().checkIfExists(true);
-    cy.findByTestId(this.addPredefinedMapperEmptyStateBtn).click({
-      force: true,
-    });
+    cy.findByTestId(this.addPredefinedMapperEmptyStateBtn).click();
     return this;
   }
 


### PR DESCRIPTION
## Motivation
Experiment to fix flaky predefined mapper test.  This test is shown to be flaky over 50% of the time on main.  It's by far the flakiest test we have.

## Brief Description
Suspect that the `force:true` flag may sometimes keep Cypress from waiting until the modal appears.

## Verification Steps
Run many times in CI to see if it is stable.
