### PR TITLE
Re-enable Dependabot updates for `react-form-hook`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     labels:
       - area/dependencies
     ignore:
-      - dependency-name: react-hook-form
-        update-types: ["version-update:semver-major"]
       - dependency-name: react
         update-types: ["version-update:semver-major"]
       - dependency-name: react-dom


### PR DESCRIPTION
Forgot to remove this when upgrading the `react-form-hook` dependency. Since it is now up-to-date we can re-enable Dependabot for it.