### PR TITLE
Fix group type label in partial import.

### DIFF
--- a/apps/admin-ui/src/realm-settings/PartialImport.tsx
+++ b/apps/admin-ui/src/realm-settings/PartialImport.tsx
@@ -443,6 +443,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
       ["USER", t("common:users")],
       ["CLIENT_ROLE", t("common:clientRoles")],
       ["IDP", t("common:identityProviders")],
+      ["GROUP", t("common:groups")],
     ]);
 
     return <span>{typeMap.get(importRecord.resourceType)}</span>;


### PR DESCRIPTION
## Motivation
Fixes #3824 

## Brief Description
Group label was missing from type column in partial import result modal.

## Verification Steps
See #3824 
