### PR TITLE
made dialog more wide when searching and used css to cut off the end when needed

### DIFF
--- a/apps/admin-ui/src/components/group/GroupPath.tsx
+++ b/apps/admin-ui/src/components/group/GroupPath.tsx
@@ -8,20 +8,6 @@ type GroupPathProps = TableTextProps & {
   group: GroupRepresentation;
 };
 
-const MAX_LENGTH = 20;
-const PART = 10;
-
-const truncatePath = (path?: string) => {
-  if (path && path.length >= MAX_LENGTH) {
-    return (
-      path.substr(0, PART) +
-      "..." +
-      path.substr(path.length - PART, path.length)
-    );
-  }
-  return path;
-};
-
 export const GroupPath = ({
   group: { path },
   onMouseEnter: onMouseEnterProp,
@@ -34,7 +20,7 @@ export const GroupPath = ({
   };
   const text = (
     <span onMouseEnter={onMouseEnter} {...props}>
-      {truncatePath(path)}
+      {path}
     </span>
   );
 

--- a/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
+++ b/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
@@ -22,6 +22,8 @@ import { ListEmptyState } from "../list-empty-state/ListEmptyState";
 import { PaginatingTableToolbar } from "../table-toolbar/PaginatingTableToolbar";
 import { GroupPath } from "./GroupPath";
 
+import "./group-picker-dialog.css";
+
 export type GroupPickerDialogProps = {
   id?: string;
   type: "selectOne" | "selectMany";
@@ -129,7 +131,7 @@ export const GroupPickerDialog = ({
 
   return (
     <Modal
-      variant={ModalVariant.small}
+      variant={filter ? ModalVariant.medium : ModalVariant.small}
       title={t(text.title, {
         group1: filterGroups?.[0]?.name,
         group2: navigation.length ? currentGroup().name : t("root"),
@@ -265,7 +267,10 @@ export const GroupPickerDialog = ({
 
                 <DataListItemCells
                   dataListCells={[
-                    <DataListCell key={`name-${group.id}`}>
+                    <DataListCell
+                      key={`name-${group.id}`}
+                      className="keycloak-groups-group-path"
+                    >
                       {filter === "" ? (
                         <span id={`select-${group.name}`}>{group.name}</span>
                       ) : (

--- a/apps/admin-ui/src/components/group/group-picker-dialog.css
+++ b/apps/admin-ui/src/components/group/group-picker-dialog.css
@@ -1,0 +1,5 @@
+.keycloak-groups-group-path {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
fixes: #4121

this creates more room for the path:
![image](https://user-images.githubusercontent.com/51133/215504998-d7e9ae9e-1097-48c6-bf1e-3f4932d900a8.png)

and when there is still not enough room it will be cut off in the end with have tooltip:
![image](https://user-images.githubusercontent.com/51133/215505927-e315db6f-ab70-40c1-8f3e-b05ad94139a6.png)


## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
