### PR TITLE
Add CIBA policy tab to authentication policies

### DIFF
--- a/apps/admin-ui/public/resources/en/authentication-help.json
+++ b/apps/admin-ui/public/resources/en/authentication-help.json
@@ -45,5 +45,6 @@
   },
   "cibaBackchannelTokenDeliveryMode": "Specifies how the CD (Consumption Device) gets the authentication result and related tokens. This mode will be used by default for the CIBA clients, which do not have other mode explicitly set.",
   "cibaExpiresIn": "The expiration time of the \"auth_req_id\" in seconds since the authentication request was received.",
-  "cibaInterval": "The minimum amount of time in seconds that the CD (Consumption Device) must wait between polling requests to the token endpoint."
+  "cibaInterval": "The minimum amount of time in seconds that the CD (Consumption Device) must wait between polling requests to the token endpoint. If set to 0, the CD must use 5 as the default value according to the CIBA specification.",
+  "cibaAuthRequestedUserHint": "The way of identifying the end-user for whom authentication is being requested. Currently only \"login_hint\" is supported."
 }

--- a/apps/admin-ui/public/resources/en/authentication-help.json
+++ b/apps/admin-ui/public/resources/en/authentication-help.json
@@ -42,5 +42,8 @@
     "digits": "The number of numerical digits required in the password string.",
     "hashAlgorithm": "Applies a hashing algorithm to passwords, so they are not stored in clear text.",
     "maxLength": "The maximum number of characters allowed in the password."
-  }
+  },
+  "cibaBackchannelTokenDeliveryMode": "Specifies how the CD (Consumption Device) gets the authentication result and related tokens. This mode will be used by default for the CIBA clients, which do not have other mode explicitly set.",
+  "cibaExpiresIn": "The expiration time of the \"auth_req_id\" in seconds since the authentication request was received.",
+  "cibaInterval": "The minimum amount of time in seconds that the CD (Consumption Device) must wait between polling requests to the token endpoint."
 }

--- a/apps/admin-ui/public/resources/en/authentication.json
+++ b/apps/admin-ui/public/resources/en/authentication.json
@@ -43,6 +43,7 @@
   },
   "cibaExpiresIn": "Expires In",
   "cibaInterval": "Interval",
+  "cibaAuthRequestedUserHint": "Authentication Requested User Hint",
   "updateCibaSuccess": "CIBA policy successfully updated",
   "updateCibaError": "Could not update CIBA policy: {{error}}",
   "webAuthnPolicySignatureAlgorithms": "Signature algorithms",

--- a/apps/admin-ui/public/resources/en/authentication.json
+++ b/apps/admin-ui/public/resources/en/authentication.json
@@ -35,6 +35,16 @@
   },
   "updateOtpSuccess": "OTP policy successfully updated",
   "updateOtpError": "Could not update OTP policy: {{error}}",
+  "cibaPolicy": "CIBA Policy",
+  "cibaBackchannelTokenDeliveryMode": "Backchannel Token Delivery Mode",
+  "cibaBackhannelTokenDeliveryModes": {
+    "poll": "Poll",
+    "ping": "Ping"
+  },
+  "cibaExpiresIn": "Expires In",
+  "cibaInterval": "Interval",
+  "updateCibaSuccess": "CIBA policy successfully updated",
+  "updateCibaError": "Could not update CIBA policy: {{error}}",
   "webAuthnPolicySignatureAlgorithms": "Signature algorithms",
   "webAuthnPolicyRpId": "Relying party ID",
   "webAuthnPolicyAttestationConveyancePreference": "Attestation conveyance preference",

--- a/apps/admin-ui/public/resources/en/common.json
+++ b/apps/admin-ui/public/resources/en/common.json
@@ -143,6 +143,8 @@
   "details": "Details",
   "required": "Required field",
   "maxLength": "Max length {{length}}",
+  "lessThan": "Must be less than {{value}}",
+  "greaterThan": "Must be greater than {{value}}",
   "createRealm": "Create Realm",
   "recent": "Recent",
   "jumpToSection": "Jump to section",

--- a/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
+++ b/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
@@ -52,7 +52,12 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
   const { adminClient } = useAdminClient();
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
-  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const [
+    backchannelTokenDeliveryModeOpen,
+    setBackchannelTokenDeliveryModeOpen,
+  ] = useState(false);
+  const [authRequestedUserHintOpen, setAuthRequestedUserHintOpen] =
+    useState(false);
 
   const setupForm = (realm: RealmRepresentation) =>
     convertToFormValues(realm, setValue);
@@ -103,13 +108,15 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
               <Select
                 toggleId="cibaBackchannelTokenDeliveryMode"
                 onSelect={(_, value) => {
-                  setIsSelectOpen(false);
+                  setBackchannelTokenDeliveryModeOpen(false);
                   field.onChange(value.toString());
                 }}
                 selections={field.value}
                 variant={SelectVariant.single}
-                isOpen={isSelectOpen}
-                onToggle={(isExpanded) => setIsSelectOpen(isExpanded)}
+                isOpen={backchannelTokenDeliveryModeOpen}
+                onToggle={(isExpanded) =>
+                  setBackchannelTokenDeliveryModeOpen(isExpanded)
+                }
               >
                 {CIBA_BACKHANNEL_TOKEN_DELIVERY_MODES.map((value) => (
                   <SelectOption
@@ -207,6 +214,30 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
               {t("common:times:seconds")}
             </InputGroupText>
           </InputGroup>
+        </FormGroup>
+        <FormGroup
+          fieldId="cibaAuthRequestedUserHint"
+          label={t("cibaAuthRequestedUserHint")}
+          labelIcon={
+            <HelpItem
+              helpText="authentication-help:cibaAuthRequestedUserHint"
+              fieldLabelId="authentication:cibaAuthRequestedUserHint"
+            />
+          }
+        >
+          <Select
+            toggleId="cibaAuthRequestedUserHint"
+            selections="login_hint"
+            isOpen={authRequestedUserHintOpen}
+            onToggle={(isExpanded) => setAuthRequestedUserHintOpen(isExpanded)}
+            isDisabled
+          >
+            <SelectOption value="login_hint">login_hint</SelectOption>
+            <SelectOption value="id_token_hint">id_token_hint</SelectOption>
+            <SelectOption value="login_hint_token">
+              login_hint_token
+            </SelectOption>
+          </Select>
         </FormGroup>
         <ActionGroup>
           <Button

--- a/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
+++ b/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   ButtonVariant,
   FormGroup,
+  InputGroup,
+  InputGroupText,
   PageSection,
   Select,
   SelectOption,
@@ -135,29 +137,34 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
           helperTextInvalid={errors.attributes?.cibaExpiresIn?.message}
           isRequired
         >
-          <KeycloakTextInput
-            id="cibaExpiresIn"
-            type="number"
-            min={CIBA_EXPIRES_IN_MIN}
-            max={CIBA_EXPIRES_IN_MAX}
-            {...register("attributes.cibaExpiresIn", {
-              min: {
-                value: CIBA_EXPIRES_IN_MIN,
-                message: t("common:greaterThan", {
+          <InputGroup>
+            <KeycloakTextInput
+              id="cibaExpiresIn"
+              type="number"
+              min={CIBA_EXPIRES_IN_MIN}
+              max={CIBA_EXPIRES_IN_MAX}
+              {...register("attributes.cibaExpiresIn", {
+                min: {
                   value: CIBA_EXPIRES_IN_MIN,
-                }),
-              },
-              max: {
-                value: CIBA_EXPIRES_IN_MAX,
-                message: t("common:lessThan", { value: CIBA_EXPIRES_IN_MAX }),
-              },
-              required: {
-                value: true,
-                message: t("common:required"),
-              },
-            })}
-            validated={errors.attributes?.cibaExpiresIn ? "error" : "default"}
-          />
+                  message: t("common:greaterThan", {
+                    value: CIBA_EXPIRES_IN_MIN,
+                  }),
+                },
+                max: {
+                  value: CIBA_EXPIRES_IN_MAX,
+                  message: t("common:lessThan", { value: CIBA_EXPIRES_IN_MAX }),
+                },
+                required: {
+                  value: true,
+                  message: t("common:required"),
+                },
+              })}
+              validated={errors.attributes?.cibaExpiresIn ? "error" : "default"}
+            />
+            <InputGroupText variant="plain">
+              {t("common:times:seconds")}
+            </InputGroupText>
+          </InputGroup>
         </FormGroup>
         <FormGroup
           fieldId="cibaInterval"
@@ -172,29 +179,34 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
           helperTextInvalid={errors.attributes?.cibaInterval?.message}
           isRequired
         >
-          <KeycloakTextInput
-            id="cibaInterval"
-            type="number"
-            min={CIBA_INTERVAL_MIN}
-            max={CIBA_INTERVAL_MAX}
-            {...register("attributes.cibaInterval", {
-              min: {
-                value: CIBA_INTERVAL_MIN,
-                message: t("common:greaterThan", {
+          <InputGroup>
+            <KeycloakTextInput
+              id="cibaInterval"
+              type="number"
+              min={CIBA_INTERVAL_MIN}
+              max={CIBA_INTERVAL_MAX}
+              {...register("attributes.cibaInterval", {
+                min: {
                   value: CIBA_INTERVAL_MIN,
-                }),
-              },
-              max: {
-                value: CIBA_INTERVAL_MAX,
-                message: t("common:lessThan", { value: CIBA_INTERVAL_MAX }),
-              },
-              required: {
-                value: true,
-                message: t("common:required"),
-              },
-            })}
-            validated={errors.attributes?.cibaInterval ? "error" : "default"}
-          />
+                  message: t("common:greaterThan", {
+                    value: CIBA_INTERVAL_MIN,
+                  }),
+                },
+                max: {
+                  value: CIBA_INTERVAL_MAX,
+                  message: t("common:lessThan", { value: CIBA_INTERVAL_MAX }),
+                },
+                required: {
+                  value: true,
+                  message: t("common:required"),
+                },
+              })}
+              validated={errors.attributes?.cibaInterval ? "error" : "default"}
+            />
+            <InputGroupText variant="plain">
+              {t("common:times:seconds")}
+            </InputGroupText>
+          </InputGroup>
         </FormGroup>
         <ActionGroup>
           <Button

--- a/apps/admin-ui/src/authentication/policies/Policies.tsx
+++ b/apps/admin-ui/src/authentication/policies/Policies.tsx
@@ -1,14 +1,15 @@
+import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 
-import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { PasswordPolicy } from "./PasswordPolicy";
+import { CibaPolicy } from "./CibaPolicy";
 import { OtpPolicy } from "./OtpPolicy";
+import { PasswordPolicy } from "./PasswordPolicy";
 import { WebauthnPolicy } from "./WebauthnPolicy";
-import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 
 export const Policies = () => {
   const { t } = useTranslation("authentication");
@@ -69,6 +70,13 @@ export const Policies = () => {
         title={<TabTitleText>{t("webauthnPasswordlessPolicy")}</TabTitleText>}
       >
         <WebauthnPolicy realm={realm} realmUpdated={setRealm} isPasswordLess />
+      </Tab>
+      <Tab
+        id="cibaPolicy"
+        eventKey={5}
+        title={<TabTitleText>{t("cibaPolicy")}</TabTitleText>}
+      >
+        <CibaPolicy realm={realm} realmUpdated={setRealm} />
       </Tab>
     </Tabs>
   );


### PR DESCRIPTION
Closes #4286.

Adds the "CIBA Policies" tab to authentication policies (Authentication :arrow_right: Policies :arrow_right: CIBA Policy). The form is different than the original in several ways:

- The "Backchannel Token Delivery Mode" is no longer marked as required, as there is always a value selected.
- Validation messages have been added for minimal and maximum values for the "Expires In" and "Interval" fields.
- The "Expires In" and "Interval" fields are now required (the original allowed saving empty values, which would error out when saving).
- ~~The "Authentication Requested User Hint" field has been omitted, as there is only one value that can be selected at all times.~~ This has been restored with a slightly different design.