### PR TITLE
Added stringify in MultiValuedStringComponent

### DIFF
--- a/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -25,7 +25,6 @@ export const MultiValuedStringComponent = ({
       fieldId={name!}
     >
       <MultiLineInput
-        aria-label={t(label!)}
         name={fieldName}
         isDisabled={isDisabled}
         defaultValue={[defaultValue]}

--- a/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -25,12 +25,14 @@ export const MultiValuedStringComponent = ({
       fieldId={name!}
     >
       <MultiLineInput
+        aria-label={t(label!)}
         name={fieldName}
         isDisabled={isDisabled}
         defaultValue={[defaultValue]}
         addButtonLabel={t("addMultivaluedLabel", {
           fieldLabel: t(label!).toLowerCase(),
         })}
+        stringify
       />
     </FormGroup>
   );


### PR DESCRIPTION
## Motivation
Fixes #4273

## Brief Description
Added missing stringify for MultiLineInput inside MultiValuedStringComponent to fix the problem of missing values in a condition with property of type MULTIVALUED_STRING_TYPE.

## Verification Steps


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
