### PR TITLE
Added aria-label to MultivaluedStringComponent

### DIFF
--- a/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -25,6 +25,7 @@ export const MultiValuedStringComponent = ({
       fieldId={name!}
     >
       <MultiLineInput
+        aria-label={t(label!)}
         name={fieldName}
         isDisabled={isDisabled}
         defaultValue={[defaultValue]}


### PR DESCRIPTION
## Motivation
Adding aria-label to MultivaluedStringComponent to get rid of error in DevTools Console. Was moved out of PR https://github.com/keycloak/keycloak-ui/pull/4306 to separate PR.

## Brief Description

## Verification Steps

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
