### PR TITLE
Don't show Groups tab if user does not have query-groups role.

### DIFF
--- a/apps/admin-ui/src/user/EditUser.tsx
+++ b/apps/admin-ui/src/user/EditUser.tsx
@@ -247,13 +247,15 @@ const EditUserForm = ({ user, bruteForced, refresh }: EditUserFormProps) => {
               >
                 <UserRoleMapping id={user.id!} name={user.username!} />
               </Tab>
-              <Tab
-                data-testid="user-groups-tab"
-                title={<TabTitleText>{t("common:groups")}</TabTitleText>}
-                {...groupsTab}
-              >
-                <UserGroups user={user} />
-              </Tab>
+              {hasAccess("query-groups") && (
+                <Tab
+                  data-testid="user-groups-tab"
+                  title={<TabTitleText>{t("common:groups")}</TabTitleText>}
+                  {...groupsTab}
+                >
+                  <UserGroups user={user} />
+                </Tab>
+              )}
               <Tab
                 data-testid="user-consents-tab"
                 title={<TabTitleText>{t("consents")}</TabTitleText>}


### PR DESCRIPTION
## Motivation
This enhancement adds support for the use case described in https://github.com/keycloak/keycloak/discussions/16769.  They want to have administrators that can only see Users but not Groups.

Fixes #4321 

## Verification Steps
Follow steps I outlined in [this comment](https://github.com/keycloak/keycloak/discussions/16769#discussioncomment-4856011).
