### PR TITLE
Adds the option to force enable new Active Directory users

### DIFF
--- a/apps/admin-ui/public/resources/en/user-federation-help.json
+++ b/apps/admin-ui/public/resources/en/user-federation-help.json
@@ -105,5 +105,6 @@
   "roleHelp": "Role to grant to user. Click 'Select Role' button to browse roles, or just type it in the textbox. To reference an application role the syntax is appname.approle, i.e. myapp.myrole.",
   "groupHelp": "Group to add the user in. Fill the full path of the group including path. For example: '/root-group/child-group'.",
   "ldapAttributeNameHelp": "Name of the LDAP attribute, which will be added to the new user during registration",
-  "ldapAttributeValueHelp": "Value of the LDAP attribute, which will be added to the new user during registration. You can either hardcode any value like 'foo' but you can also use some special tokens. Only supported token right now is '${RANDOM}', which will be replaced with some randomly generated string."
+  "ldapAttributeValueHelp": "Value of the LDAP attribute, which will be added to the new user during registration. You can either hardcode any value like 'foo' but you can also use some special tokens. Only supported token right now is '${RANDOM}', which will be replaced with some randomly generated string.",
+  "enableAdUserHelp": "Create a random value for 'unicodePwd' and set the 'userAccountControl' attribute to 512 immediately after the user is registered, so that new users are enabled by default. This setting applies only to Active Directory."
 }

--- a/apps/admin-ui/public/resources/en/user-federation.json
+++ b/apps/admin-ui/public/resources/en/user-federation.json
@@ -174,5 +174,6 @@
   "providerType": "Provider Type",
   "parentId": "Parent ID",
   "kerberosPrincipal": "Kerberos Principal",
-  "kerberosKeyTab": "Kerberos Key Tab"
+  "kerberosKeyTab": "Kerberos Key Tab",
+  "enableAdUser": "Force enable AD user upon creation"
 }

--- a/apps/admin-ui/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/apps/admin-ui/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -92,7 +92,34 @@ export const LdapSettingsAdvanced = ({
             )}
           ></Controller>
         </FormGroup>
-
+        <FormGroup
+          hasNoPaddingTop
+          label={t("enableAdUser")}
+          labelIcon={
+            <HelpItem
+              helpText="user-federation-help:enableAdUserHelp"
+              fieldLabelId="user-federation:enableAdUser"
+            />
+          }
+          fieldId="kc-enable-ad-user"
+        >
+          <Controller
+            name="config.enableAdUser"
+            defaultValue={["false"]}
+            control={form.control}
+            render={({ field }) => (
+              <Switch
+                id="kc-enable-ad-user"
+                data-testid="enable-ad-user"
+                label={t("common:on")}
+                labelOff={t("common:off")}
+                onChange={(value) => field.onChange([`${value}`])}
+                isChecked={field.value[0] === "true"}
+                aria-label={t("enableAdUser")}
+              />
+            )}
+          />
+        </FormGroup>
         <FormGroup
           label={t("validatePasswordPolicy")}
           labelIcon={


### PR DESCRIPTION
Gives the users the option to enable new users on Active Directory.

This is the accompanying UI change to the PR submitted to the server
repo: https://github.com/keycloak/keycloak/pull/16980

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
