### PR TITLE
Fix 'Home URL' link in clients overview

### DIFF
--- a/apps/admin-ui/src/clients/ClientsSection.tsx
+++ b/apps/admin-ui/src/clients/ClientsSection.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { formattedLinkTableCell } from "../components/external-link/FormattedLink";
+import { FormattedLink } from "../components/external-link/FormattedLink";
 import {
   Action,
   KeycloakDataTable,
@@ -67,6 +67,17 @@ const ClientDescription = (client: ClientRepresentation) => (
     {emptyFormatter()(client.description)}
   </TableText>
 );
+
+const ClientHomeLink = (client: ClientRepresentation) => {
+  const { adminClient } = useAdminClient();
+  const href = convertClientToUrl(client, adminClient.baseUrl);
+
+  if (!href) {
+    return "—";
+  }
+
+  return <FormattedLink href={href} />;
+};
 
 export default function ClientsSection() {
   const { t } = useTranslation("clients");
@@ -233,9 +244,7 @@ export default function ClientsSection() {
                   name: "baseUrl",
                   displayKey: "clients:homeURL",
                   transforms: [cellWidth(20)],
-                  cellFormatters: [formattedLinkTableCell(), emptyFormatter()],
-                  cellRenderer: (c) =>
-                    convertClientToUrl(c, adminClient.baseUrl) || "",
+                  cellRenderer: ClientHomeLink,
                 },
               ]}
             />

--- a/apps/admin-ui/src/components/external-link/FormattedLink.tsx
+++ b/apps/admin-ui/src/components/external-link/FormattedLink.tsx
@@ -1,6 +1,5 @@
-import { AnchorHTMLAttributes } from "react";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons";
-import type { IFormatter, IFormatterValueType } from "@patternfly/react-table";
+import { AnchorHTMLAttributes } from "react";
 
 export type FormattedLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   isInline?: boolean;
@@ -25,10 +24,3 @@ export const FormattedLink = ({
     </a>
   );
 };
-
-export const formattedLinkTableCell =
-  (): IFormatter => (data?: IFormatterValueType) => {
-    return (
-      data ? <FormattedLink href={data.toString()} /> : undefined
-    ) as object;
-  };


### PR DESCRIPTION
Ran into this bug when working on the clients overview for an unrelated reason. I noticed that the 'Home URL' links in the table on the clients overview were getting malformed (and also the link target).

Before:
![Screenshot 2023-02-09 at 18-33-19 Keycloak Administration UI](https://user-images.githubusercontent.com/695720/217892784-82450c95-723f-4531-bf27-d964327cf6cb.png)

After:
![Screenshot 2023-02-09 at 18-33-40 Keycloak Administration UI](https://user-images.githubusercontent.com/695720/217892826-bfad4771-b59a-4c7e-b47e-3affd2462746.png)
