### PR TITLE
Update React Hook Form to latest version

### DIFF
--- a/apps/account-ui/package.json
+++ b/apps/account-ui/package.json
@@ -16,7 +16,7 @@
     "keycloak-masthead": "999.0.0-dev",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^7.38.0",
+    "react-hook-form": "^7.43.1",
     "react-i18next": "^12.1.5",
     "react-router-dom": "6.8.1",
     "ui-shared": "999.0.0-dev"

--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -79,7 +79,7 @@
     "react-dom": "^17.0.2",
     "react-dropzone": "^14.2.3",
     "react-error-boundary": "^3.1.4",
-    "react-hook-form": "^7.42.1",
+    "react-hook-form": "^7.43.1",
     "react-i18next": "^12.1.5",
     "react-router-dom": "6.8.1",
     "reactflow": "^11.5.5",

--- a/libs/ui-shared/package.json
+++ b/libs/ui-shared/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@patternfly/react-core": "^4.267.6",
-    "react-hook-form": "7.42.1",
+    "react-hook-form": "7.43.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "keycloak-masthead": "999.0.0-dev",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-hook-form": "^7.38.0",
+        "react-hook-form": "^7.43.1",
         "react-i18next": "^12.1.5",
         "react-router-dom": "6.8.1",
         "ui-shared": "999.0.0-dev"
@@ -77,7 +77,7 @@
         "react-dom": "^17.0.2",
         "react-dropzone": "^14.2.3",
         "react-error-boundary": "^3.1.4",
-        "react-hook-form": "^7.42.1",
+        "react-hook-form": "^7.43.1",
         "react-i18next": "^12.1.5",
         "react-router-dom": "6.8.1",
         "reactflow": "^11.5.5",
@@ -510,7 +510,7 @@
         "@patternfly/react-core": "^4.267.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-hook-form": "7.42.1"
+        "react-hook-form": "7.43.1"
       },
       "devDependencies": {
         "@types/react": "^17.0.53",
@@ -14157,9 +14157,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.42.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
-      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
+      "version": "7.43.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.1.tgz",
+      "integrity": "sha512-+s3+s8LLytRMriwwuSqeLStVjRXFGxgjjx2jED7Z+wz1J/88vpxieRQGvJVvzrzVxshZ0BRuocFERb779m2kNg==",
       "engines": {
         "node": ">=12.22.0"
       },


### PR DESCRIPTION
Dependabot is ignoring this version, so hopefully updating this will re-start it.