### PR TITLE
Ensure client certificate is uploaded as a file

### DIFF
--- a/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -93,9 +93,11 @@ export const Keys = ({ clientId, save, hasConfigureAccess }: KeysProps) => {
     try {
       const formData = new FormData();
       const { file, ...rest } = importFile;
-      Object.entries(rest).map((entry) =>
-        formData.append(entry[0], entry[1] as string)
-      );
+
+      for (const [key, value] of Object.entries(rest)) {
+        formData.append(key, value);
+      }
+
       formData.append("file", file.value!);
 
       await adminClient.clients.uploadCertificate(

--- a/libs/keycloak-admin-client/src/resources/agent.ts
+++ b/libs/keycloak-admin-client/src/resources/agent.ts
@@ -209,6 +209,8 @@ export class Agent {
     } else if (requestHeaders.get("content-type") === "text/plain") {
       // Pass the payload as a plain string if the content type is 'text/plain'.
       requestOptions.body = payload as unknown as string;
+    } else if (payload instanceof FormData) {
+      requestOptions.body = payload;
     } else {
       // Otherwise assume it's JSON and stringify it.
       requestOptions.body = JSON.stringify(
@@ -216,7 +218,7 @@ export class Agent {
       );
     }
 
-    if (!requestHeaders.has("content-type")) {
+    if (!requestHeaders.has("content-type") && !(payload instanceof FormData)) {
       requestHeaders.set("content-type", "application/json");
     }
 

--- a/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/libs/keycloak-admin-client/src/resources/clients.ts
@@ -987,7 +987,7 @@ export class Clients extends Resource<{ realm?: string }> {
 
   public uploadCertificate = this.makeUpdateRequest<
     { id: string; attr: string },
-    any
+    FormData
   >({
     method: "POST",
     path: "/{id}/certificates/{attr}/upload-certificate",


### PR DESCRIPTION
Ensure client certificate is uploaded as a file instead of JSON (which throws an exception). This also addresses a bug in the admin client, which could not properly handle [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData) being passed into it.

Closes #4342.