### PR TITLE
Consistent language fallbacks for admin ui theme

### DIFF
--- a/apps/admin-ui/cypress/e2e/i18n_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/i18n_test.spec.ts
@@ -1,0 +1,177 @@
+import LoginPage from "../support/pages/LoginPage";
+import SidebarPage from "../support/pages/admin-ui/SidebarPage";
+import adminClient from "../support/util/AdminClient";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
+import ProviderPage from "../support/pages/admin-ui/manage/providers/ProviderPage";
+
+const loginPage = new LoginPage();
+const sidebarPage = new SidebarPage();
+
+const providersPage = new ProviderPage();
+
+const usernameI18nTest = "user_i18n_test";
+let usernameI18nId: string;
+
+let originallySupportedLocales: string[] | null = null;
+
+describe("i18n tests", () => {
+  before(() => {
+    cy.wrap(null).then(async () => {
+      const realm = (await adminClient.getRealm("master"))!;
+      originallySupportedLocales = realm.supportedLocales ?? [];
+      realm.supportedLocales = ["en", "de", "de-CH", "fo"];
+      await adminClient.updateRealm("master", realm);
+
+      const { id: userId } = await adminClient.createUser({
+        username: usernameI18nTest,
+        enabled: true,
+        credentials: [
+          { type: "password", temporary: false, value: usernameI18nTest },
+        ],
+      });
+      usernameI18nId = userId;
+
+      await adminClient.addRealmRoleToUser(usernameI18nId, "admin");
+    });
+  });
+
+  after(async () => {
+    await adminClient.deleteUser(usernameI18nTest);
+
+    if (originallySupportedLocales) {
+      const realm = (await adminClient.getRealm("master"))!;
+      realm.supportedLocales = originallySupportedLocales;
+      await adminClient.updateRealm("master", realm);
+    }
+  });
+
+  afterEach(async () => {
+    await adminClient.removeAllLocalizationTexts();
+  });
+
+  const realmLocalizationEn = "realmSettings en";
+  const themeLocalizationEn = "Realm settings";
+  const realmLocalizationDe = "realmSettings de";
+  const themeLocalizationDe = "Realm-Einstellungen";
+  const realmLocalizationDeCh = "realmSettings de-CH";
+
+  it("should use THEME localization for fallback (en) when language without theme localization is requested and no realm localization exists", () => {
+    updateUserLocale("fo");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(themeLocalizationEn);
+  });
+
+  it("should use THEME localization for language when language with theme localization is requested and no realm localization exists", () => {
+    updateUserLocale("de");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(themeLocalizationDe);
+  });
+
+  it("should use REALM localization for fallback (en) when language without theme localization is requested and realm localization exists for fallback (en)", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    updateUserLocale("fo");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationEn);
+  });
+
+  it("should use THEME localization for language when language with theme localization is requested and realm localization exists for fallback (en) only", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    updateUserLocale("de");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(themeLocalizationDe);
+  });
+
+  it("should use REALM localization for language when language is requested and realm localization exists for language", () => {
+    addCommonRealmSettingsLocalizationText("de", realmLocalizationDe);
+    updateUserLocale("de");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDe);
+  });
+
+  it("should use REALM localization for region when region is requested and realm localization exists for region", () => {
+    addCommonRealmSettingsLocalizationText("de-CH", realmLocalizationDeCh);
+    updateUserLocale("de-CH");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDeCh);
+  });
+
+  it("should use REALM localization for language when language is requested and realm localization exists for fallback (en), language, region", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    addCommonRealmSettingsLocalizationText("de", realmLocalizationDe);
+    addCommonRealmSettingsLocalizationText("de-CH", realmLocalizationDeCh);
+    updateUserLocale("de");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDe);
+  });
+
+  it("should use REALM localization for language when region is requested and realm localization exists for fallback (en), language", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    addCommonRealmSettingsLocalizationText("de", realmLocalizationDe);
+    updateUserLocale("de-CH");
+
+    goToUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDe);
+  });
+
+  it("should apply plurals and interpolation for THEME localization", () => {
+    updateUserLocale("en");
+
+    goToUserFederationPage();
+
+    // check key "user-federation:addProvider_other"
+    providersPage.assertCardContainsText("ldap", "Add Ldap providers");
+  });
+
+  it("should apply plurals and interpolation for REALM localization", () => {
+    addLocalization(
+      "en",
+      "user-federation:addProvider_other",
+      "addProvider_other en: {{provider}}"
+    );
+    updateUserLocale("en");
+
+    goToUserFederationPage();
+
+    providersPage.assertCardContainsText("ldap", "addProvider_other en: Ldap");
+  });
+
+  function goToUserFederationPage() {
+    loginPage.logIn(usernameI18nTest, usernameI18nTest);
+    keycloakBefore();
+    sidebarPage.goToUserFederation();
+  }
+
+  function updateUserLocale(locale: string) {
+    cy.wrap(null).then(() =>
+      adminClient.updateUser(usernameI18nId, { attributes: { locale: locale } })
+    );
+  }
+
+  function addCommonRealmSettingsLocalizationText(
+    locale: string,
+    value: string
+  ) {
+    addLocalization(locale, "common:realmSettings", value);
+  }
+
+  function addLocalization(locale: string, key: string, value: string) {
+    cy.wrap(null).then(() =>
+      adminClient.addLocalizationText(locale, key, value)
+    );
+  }
+});

--- a/apps/admin-ui/cypress/support/pages/admin-ui/SidebarPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/SidebarPage.ts
@@ -142,4 +142,8 @@ export default class SidebarPage extends CommonElements {
     cy.get('[role="progressbar"]').should("not.exist");
     return this;
   }
+
+  checkRealmSettingsLinkContainsText(expectedText: string) {
+    cy.get(this.realmSettingsBtn).should("contain", expectedText);
+  }
 }

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/providers/ProviderPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/providers/ProviderPage.ts
@@ -430,6 +430,11 @@ export default class ProviderPage {
     return this;
   }
 
+  assertCardContainsText(providerType: string, expectedText: string) {
+    cy.findByTestId(`${providerType}-card`).should("contain", expectedText);
+    return this;
+  }
+
   disableEnabledSwitch(providerType: string) {
     cy.get(`#${providerType}-switch`).uncheck({ force: true });
     return this;

--- a/apps/admin-ui/src/context/whoami/WhoAmI.tsx
+++ b/apps/admin-ui/src/context/whoami/WhoAmI.tsx
@@ -12,7 +12,8 @@ export class WhoAmI {
   constructor(private me?: WhoAmIRepresentation) {
     if (this.me?.locale) {
       i18n.changeLanguage(this.me.locale, (error) => {
-        if (error) console.error("Unable to set locale to", this.me?.locale);
+        if (error)
+          console.warn("Error(s) loading locale", this.me?.locale, error);
       });
     }
   }


### PR DESCRIPTION
- i18next does not support variants, hence the prio of messages is as follows (RL = realm localization, T = Theme i18n files): RL \<region> > T \<region> > RL \<language> > T \<language> > RL en > T en
- remove the param useRealmDefaultLocaleFallback=true from the call to /admin/realms/{realm}/localization/{locale}, because otherwise realm localization texts of the realm default language would overwrite more specific texts from translation files (and unnecessary data will be loaded)
- add cypress test i18n_test.spec.ts, which checks the fallback implementation
- log a warning instead of an error, when messages for some languages/namespaces cannot be loaded (the page will probably work with fallbacks in that case)

Closes #4390

## Motivation
This is the admin ui part of https://github.com/keycloak/keycloak/pull/17076

## Brief Description
Changes the prio of localized messages as follows (RL = realm localization, T = Theme i18n files): RL \<region> > T \<region> > RL \<language> > T \<language> > RL en > T en

## Verification Steps
See the tests in i18n_test.spec.ts

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [not relevant] Help has been implemented
- [?] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
Only works completely when this Keycloak PR has been merged: https://github.com/keycloak/keycloak/pull/17076
