### PR TITLE
moved help text into dropdown

### DIFF
--- a/apps/admin-ui/src/components/download-dialog/DownloadDialog.tsx
+++ b/apps/admin-ui/src/components/download-dialog/DownloadDialog.tsx
@@ -1,6 +1,4 @@
 import {
-  Alert,
-  AlertVariant,
   Form,
   FormGroup,
   ModalVariant,
@@ -111,22 +109,6 @@ export const DownloadDialog = ({
     >
       <Form>
         <Stack hasGutter>
-          {enabled && (
-            <StackItem>
-              <Alert
-                id={id}
-                title={t("clients:description")}
-                variant={AlertVariant.info}
-                isInline
-              >
-                {
-                  configFormats.find(
-                    (configFormat) => configFormat.id === selected
-                  )?.helpText
-                }
-              </Alert>
-            </StackItem>
-          )}
           <StackItem>
             <FormGroup
               fieldId="type"
@@ -157,6 +139,7 @@ export const DownloadDialog = ({
                     key={configFormat.id}
                     value={configFormat.id}
                     isSelected={selected === configFormat.id}
+                    description={enabled ? configFormat.helpText : undefined}
                   >
                     {configFormat.displayType}
                   </SelectOption>


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
After a review from Kun it seemed best to move the helptext into the combobox so users can see it before they select.

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
