### PR TITLE
Use new root API to render Account UI

### DIFF
--- a/apps/account-ui/src/main.tsx
+++ b/apps/account-ui/src/main.tsx
@@ -2,7 +2,7 @@ import "@patternfly/react-core/dist/styles/base.css";
 import "@patternfly/patternfly/patternfly-addons.css";
 
 import { StrictMode } from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { i18n } from "./i18n";
@@ -20,10 +20,10 @@ await Promise.all([
 
 const router = createBrowserRouter(routes);
 const container = document.getElementById("app");
+const root = createRoot(container!);
 
-render(
+root.render(
   <StrictMode>
     <RouterProvider router={router} />
-  </StrictMode>,
-  container
+  </StrictMode>
 );


### PR DESCRIPTION
Moves the Account UI to the new root API for React 18 (see [upgrade guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis)).