### PR TITLE
Move smtp warning so it will be seen without scrolling.

### DIFF
--- a/apps/admin-ui/src/realm-settings/EmailTab.tsx
+++ b/apps/admin-ui/src/realm-settings/EmailTab.tsx
@@ -333,43 +333,6 @@ export const RealmSettingsEmailTab = ({
               </FormGroup>
             </>
           )}
-
-          <ActionGroup>
-            <ActionListItem>
-              <Button
-                variant="primary"
-                type="submit"
-                data-testid="email-tab-save"
-              >
-                {t("common:save")}
-              </Button>
-            </ActionListItem>
-            <ActionListItem>
-              <Button
-                variant="secondary"
-                onClick={() => testConnection()}
-                data-testid="test-connection-button"
-                isDisabled={
-                  !(emailRegexPattern.test(watchFromValue) && watchHostValue) ||
-                  !currentUser?.email
-                }
-                aria-describedby="descriptionTestConnection"
-                isLoading={isTesting}
-                spinnerAriaValueText={t("testingConnection")}
-              >
-                {t("common:testConnection")}
-              </Button>
-            </ActionListItem>
-            <ActionListItem>
-              <Button
-                variant="link"
-                onClick={reset}
-                data-testid="email-tab-revert"
-              >
-                {t("common:revert")}
-              </Button>
-            </ActionListItem>
-          </ActionGroup>
           {currentUser && (
             <FormGroup id="descriptionTestConnection">
               {currentUser.email ? (
@@ -407,6 +370,42 @@ export const RealmSettingsEmailTab = ({
               )}
             </FormGroup>
           )}
+          <ActionGroup>
+            <ActionListItem>
+              <Button
+                variant="primary"
+                type="submit"
+                data-testid="email-tab-save"
+              >
+                {t("common:save")}
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button
+                variant="secondary"
+                onClick={() => testConnection()}
+                data-testid="test-connection-button"
+                isDisabled={
+                  !(emailRegexPattern.test(watchFromValue) && watchHostValue) ||
+                  !currentUser?.email
+                }
+                aria-describedby="descriptionTestConnection"
+                isLoading={isTesting}
+                spinnerAriaValueText={t("testingConnection")}
+              >
+                {t("common:testConnection")}
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button
+                variant="link"
+                onClick={reset}
+                data-testid="email-tab-revert"
+              >
+                {t("common:revert")}
+              </Button>
+            </ActionListItem>
+          </ActionGroup>
         </FormAccess>
       </FormPanel>
     </PageSection>


### PR DESCRIPTION
## Motivation
Fixes #4420 

## Brief Description
Warning message `To test the connection you must first configure an e-mail address for the current user (admin).` might be hidden if user does not scroll to the bottom.  This can lead the user to think that the SMTP `Test connection` button is improperly disabled.

## Verification Steps
1. In user section, remove email for current user.
2. See warning message now appears above `Test connection` button instead of below it.
