### PR TITLE
Add thTooltipText prop to DraggableTable component

### DIFF
--- a/apps/admin-ui/public/resources/en/authentication-help.json
+++ b/apps/admin-ui/public/resources/en/authentication-help.json
@@ -7,6 +7,7 @@
   "addExecution": "Execution can have a wide range of actions, from sending a reset email to validating an OTP",
   "addSubFlow": "Sub-Flows can be either generic or form. The form type is used to construct a sub-flow that generates a single flow for the user. Sub-flows are a special type of execution that evaluate as successful depending on how the executions they contain evaluate.",
   "alias": "Name of the configuration",
+  "authDefaultActionTooltip": "If enabled, any new user will have this required action assigned to it.",
   "otpType": "totp is Time-Based One Time Password. 'hotp' is a counter base one time password in which the server keeps a counter to hash against.",
   "webAuthnPolicyRpEntityName": "Human-readable server name as WebAuthn Relying Party",
   "otpHashAlgorithm": "What hashing algorithm should be used to generate the OTP.",

--- a/apps/admin-ui/src/authentication/RequiredActions.tsx
+++ b/apps/admin-ui/src/authentication/RequiredActions.tsx
@@ -152,6 +152,7 @@ export const RequiredActions = () => {
         {
           name: "default",
           displayKey: "authentication:setAsDefaultAction",
+          thTooltipText: "authentication-help:authDefaultActionTooltip",
           cellRenderer: (row) => (
             <Switch
               id={`default-${toKey(row.name)}`}

--- a/apps/admin-ui/src/authentication/components/DraggableTable.tsx
+++ b/apps/admin-ui/src/authentication/components/DraggableTable.tsx
@@ -18,12 +18,14 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { ThInfoType } from "@patternfly/react-table/components/Table/base/types";
 import styles from "@patternfly/react-styles/css/components/DataList/data-list";
 
 export type Field<T> = {
   name: string;
   displayKey?: string;
   cellRenderer?: (row: T) => ReactNode;
+  thTooltipText?: string;
 };
 
 export type Action<T> = IAction & { isActionable?: (item: T) => boolean };
@@ -179,6 +181,14 @@ export function DraggableTable<T>({
     });
   };
 
+  const thInfo = (column: Field<T>): ThInfoType | undefined => {
+    if (!column.thTooltipText) return undefined;
+    return {
+      popover: <div>{t(column.thTooltipText)}</div>,
+      ariaLabel: t(column.thTooltipText),
+    };
+  };
+
   return (
     <TableComposable
       aria-label="Draggable table"
@@ -189,7 +199,9 @@ export function DraggableTable<T>({
         <Tr>
           <Th />
           {columns.map((column) => (
-            <Th key={column.name}>{t(column.displayKey || column.name)}</Th>
+            <Th key={column.name} info={thInfo(column)}>
+              {t(column.displayKey || column.name)}
+            </Th>
           ))}
         </Tr>
       </Thead>


### PR DESCRIPTION
This commit adds a new column field called `thTooltipText` to the `DraggableTable` component, which allows users to add a tooltip next to the column name in the `th` of the table.

## Motivation
There used to be a tooltip text next to "Default Action" text on the "Authentication" view. This PR adds it back in.
<img width="938" alt="Screenshot 2023-02-21 at 19 06 35" src="https://user-images.githubusercontent.com/52921312/220443619-547ac4f1-490d-4ae2-9f02-f540e966d084.png">


## Brief Description
This PR adds a new optional column field called `thTooltipText` to the DraggableTable component. With this field, a tooltip text can be provided like this:
```jsx
<DraggableTable
  columns={[
    {
      name: "default",
      displayKey: "authentication:setAsDefaultAction",
      thTooltipText: "authentication-help:authDefaultActionTooltip"
    }
  ]}
>
</DraggableTable>
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes

Before
<img width="1728" alt="Screenshot 2023-02-21 at 19 09 06" src="https://user-images.githubusercontent.com/52921312/220443696-ec132432-7b8f-4310-92c9-93b82a68fded.png">

After
<img width="1727" alt="Screenshot 2023-02-21 at 19 08 55" src="https://user-images.githubusercontent.com/52921312/220443647-83b05b23-4ff2-4045-b1df-6ec48044f85b.png">

