### PR TITLE
Fix checkout of Keycloak server for release branches

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Check out Keycloak Server
         uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.keycloakRepo || (contains(github.ref, 'release/') && github.ref || 'keycloak/keycloak') }}
-          ref: ${{ inputs.keycloakBranch || 'main' }}
+          repository: ${{ inputs.keycloakRepo || 'keycloak/keycloak' }}
+          ref: ${{ inputs.keycloakBranch || (contains(github.ref, 'release/') && github.ref || 'main') }}
           path: keycloak-repo
 
       - name: Set up Java


### PR DESCRIPTION
There was some issues running Cypress tests for release/21.0:

![image](https://user-images.githubusercontent.com/2271511/220855633-70d27af9-358a-41bf-a860-097dd7ffcaed.png)

It was using github.ref for the repository, rather than for ref, when checking out Keycloak sources.

This is a "forward port" from fixing it in `release/21.0` branch:

https://github.com/keycloak/keycloak-ui/commit/21000a73098dbab70ec73d91d2905113dfd4b64f