### PR TITLE
Switched from crypto.randomUUID() to uuid library.

### DIFF
--- a/apps/admin-ui/cypress/e2e/authentication_policies_ciba.spec.ts
+++ b/apps/admin-ui/cypress/e2e/authentication_policies_ciba.spec.ts
@@ -6,12 +6,13 @@ import SidebarPage from "../support/pages/admin-ui/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
 import adminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
 
 describe("Authentication - Policies - CIBA", () => {
-  const realmName = crypto.randomUUID();
+  const realmName = uuidv4();
 
   before(() => adminClient.createRealm(realmName));
   after(() => adminClient.deleteRealm(realmName));

--- a/apps/admin-ui/cypress/e2e/authentication_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/authentication_test.spec.ts
@@ -11,13 +11,14 @@ import PasswordPolicies from "../support/pages/admin-ui/manage/authentication/Pa
 import ModalUtils from "../support/util/ModalUtils";
 import CommonPage from "../support/pages/CommonPage";
 import BindFlowModal from "../support/pages/admin-ui/manage/authentication/BindFlowModal";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
 const sidebarPage = new SidebarPage();
 const commonPage = new CommonPage();
 const listingPage = new ListingPage();
-const realmName = "test" + crypto.randomUUID();
+const realmName = "test" + uuidv4();
 
 describe("Authentication test", () => {
   const detailPage = new FlowDetails();

--- a/apps/admin-ui/cypress/e2e/client_authorization_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/client_authorization_test.spec.ts
@@ -10,6 +10,7 @@ import ClientDetailsPage from "../support/pages/admin-ui/manage/clients/client_d
 import PoliciesTab from "../support/pages/admin-ui/manage/clients/client_details/tabs/authorization_subtabs/PoliciesTab";
 import PermissionsTab from "../support/pages/admin-ui/manage/clients/client_details/tabs/authorization_subtabs/PermissionsTab";
 import CreateResourcePage from "../support/pages/admin-ui/manage/clients/client_details/CreateResourcePage";
+import { v4 as uuidv4 } from "uuid";
 
 describe("Client authentication subtab", () => {
   const loginPage = new LoginPage();
@@ -20,7 +21,7 @@ describe("Client authentication subtab", () => {
   const clientDetailsPage = new ClientDetailsPage();
   const policiesSubTab = new PoliciesTab();
   const permissionsSubTab = new PermissionsTab();
-  const clientId = "client-authentication-" + crypto.randomUUID();
+  const clientId = "client-authentication-" + uuidv4();
 
   before(() =>
     adminClient.createClient({

--- a/apps/admin-ui/cypress/e2e/client_scopes_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/client_scopes_test.spec.ts
@@ -17,6 +17,7 @@ import MappersTab from "../support/pages/admin-ui/manage/client_scopes/client_sc
 import MapperDetailsPage, {
   ClaimJsonType,
 } from "../support/pages/admin-ui/manage/client_scopes/client_scope_details/tabs/mappers/MapperDetailsPage";
+import { v4 as uuidv4 } from "uuid";
 
 let itemId = "client_scope_crud";
 const loginPage = new LoginPage();
@@ -291,7 +292,7 @@ describe("Client Scopes test", () => {
     });
 
     it("Client scope CRUD test", () => {
-      itemId += "_" + crypto.randomUUID();
+      itemId += "_" + uuidv4();
 
       // Create
       listingPage.itemExist(itemId, false).goToCreateItem();

--- a/apps/admin-ui/cypress/e2e/clients_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/clients_test.spec.ts
@@ -18,6 +18,7 @@ import ClientDetailsPage, {
 import CommonPage from "../support/pages/CommonPage";
 import AttributesTab from "../support/pages/admin-ui/manage/AttributesTab";
 import DedicatedScopesMappersTab from "../support/pages/admin-ui/manage/clients/client_details/DedicatedScopesMappersTab";
+import { v4 as uuidv4 } from "uuid";
 
 let itemId = "client_crud";
 const loginPage = new LoginPage();
@@ -313,7 +314,7 @@ describe("Clients test", () => {
     });
 
     it("Client CRUD test", () => {
-      itemId += "_" + crypto.randomUUID();
+      itemId += "_" + uuidv4();
 
       // Create
       commonPage.tableUtils().checkRowItemExists(itemId, false);
@@ -480,7 +481,7 @@ describe("Clients test", () => {
 
   describe("Roles tab test", () => {
     const rolesTab = new ClientRolesTab();
-    const client = "client_" + crypto.randomUUID();
+    const client = "client_" + uuidv4();
 
     before(() =>
       adminClient.createClient({
@@ -685,7 +686,7 @@ describe("Clients test", () => {
       loginPage.logIn();
       keycloakBefore();
       commonPage.sidebar().goToClients();
-      client = "client_" + crypto.randomUUID();
+      client = "client_" + uuidv4();
       commonPage.tableToolbarUtils().createClient();
       createClientPage
         .selectClientType("openid-connect")

--- a/apps/admin-ui/cypress/e2e/events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/events_test.spec.ts
@@ -12,6 +12,7 @@ import EventsPage, {
 } from "../support/pages/admin-ui/manage/events/EventsPage";
 import ListingPage from "../support/pages/admin-ui/ListingPage";
 import adminClient from "../support/util/AdminClient";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -33,7 +34,7 @@ describe("Events tests", () => {
   const eventsTestUser = {
     eventsTestUserId: "",
     userRepresentation: {
-      username: "events-test" + crypto.randomUUID(),
+      username: "events-test" + uuidv4(),
       enabled: true,
       credentials: [{ value: "events-test" }],
     },

--- a/apps/admin-ui/cypress/e2e/group_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/group_test.spec.ts
@@ -12,6 +12,7 @@ import adminClient from "../support/util/AdminClient";
 import { range } from "lodash-es";
 import RoleMappingTab from "../support/pages/admin-ui/manage/RoleMappingTab";
 import CommonPage from "../support/pages/CommonPage";
+import { v4 as uuidv4 } from "uuid";
 
 describe("Group test", () => {
   const loginPage = new LoginPage();
@@ -55,7 +56,7 @@ describe("Group test", () => {
     loginPage.logIn();
     keycloakBefore();
     sidebarPage.goToGroups();
-    groupName = groupNamePrefix + crypto.randomUUID();
+    groupName = groupNamePrefix + uuidv4();
     groupNames.push(groupName);
   });
 

--- a/apps/admin-ui/cypress/e2e/realm_roles_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_roles_test.spec.ts
@@ -9,6 +9,7 @@ import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 import ClientRolesTab from "../support/pages/admin-ui/manage/clients/ClientRolesTab";
 import KeyValueInput from "../support/pages/admin-ui/manage/KeyValueInput";
+import { v4 as uuidv4 } from "uuid";
 
 let itemId = "realm_role_crud";
 const loginPage = new LoginPage();
@@ -46,7 +47,7 @@ describe("Realm roles test", () => {
   });
 
   it("Realm role CRUD test", () => {
-    itemId += "_" + crypto.randomUUID();
+    itemId += "_" + uuidv4();
 
     // Create
     listingPage.itemExist(itemId, false).goToCreateItem();
@@ -69,7 +70,7 @@ describe("Realm roles test", () => {
   });
 
   it("should delete role from details action", () => {
-    itemId += "_" + crypto.randomUUID();
+    itemId += "_" + uuidv4();
     listingPage.goToCreateItem();
     createRealmRolePage.fillRealmRoleData(itemId).save();
     masthead.checkNotificationMessage("Role created", true);
@@ -89,7 +90,7 @@ describe("Realm roles test", () => {
   });
 
   it("Add associated roles test", () => {
-    itemId += "_" + crypto.randomUUID();
+    itemId += "_" + uuidv4();
 
     // Create
     listingPage.itemExist(itemId, false).goToCreateItem();
@@ -183,7 +184,7 @@ describe("Realm roles test", () => {
 
   it("Should delete associated roles from list test", () => {
     itemId = "realm_role_crud";
-    itemId += "_" + crypto.randomUUID();
+    itemId += "_" + uuidv4();
 
     // Create
     listingPage.itemExist(itemId, false).goToCreateItem();

--- a/apps/admin-ui/cypress/e2e/realm_settings_client_policies_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_client_policies_test.spec.ts
@@ -5,6 +5,7 @@ import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
 import Masthead from "../support/pages/admin-ui/Masthead";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -12,7 +13,7 @@ const modalUtils = new ModalUtils();
 const masthead = new Masthead();
 
 describe("Realm settings client policies tab tests", () => {
-  const realmName = "Realm_" + crypto.randomUUID();
+  const realmName = "Realm_" + uuidv4();
   const realmSettingsPage = new RealmSettingsPage(realmName);
 
   beforeEach(() => {

--- a/apps/admin-ui/cypress/e2e/realm_settings_client_profiles_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_client_profiles_test.spec.ts
@@ -5,6 +5,7 @@ import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
 import Masthead from "../support/pages/admin-ui/Masthead";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -14,7 +15,7 @@ const masthead = new Masthead();
 describe("Realm settings client profiles tab tests", () => {
   const profileName = "Test";
   const editedProfileName = "Edit";
-  const realmName = "Realm_" + crypto.randomUUID();
+  const realmName = "Realm_" + uuidv4();
   const realmSettingsPage = new RealmSettingsPage(realmName);
 
   beforeEach(() => {

--- a/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_events_test.spec.ts
@@ -6,6 +6,7 @@ import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import ListingPage from "../support/pages/admin-ui/ListingPage";
 import adminClient from "../support/util/AdminClient";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -14,7 +15,7 @@ const modalUtils = new ModalUtils();
 const realmSettingsPage = new RealmSettingsPage();
 
 describe("Realm settings events tab tests", () => {
-  const realmName = "Realm_" + crypto.randomUUID();
+  const realmName = "Realm_" + uuidv4();
   const listingPage = new ListingPage();
 
   beforeEach(() => {
@@ -87,10 +88,7 @@ describe("Realm settings events tab tests", () => {
   };
 
   const addBundle = () => {
-    realmSettingsPage.addKeyValuePair(
-      "key_" + crypto.randomUUID(),
-      "value_" + crypto.randomUUID()
-    );
+    realmSettingsPage.addKeyValuePair("key_" + uuidv4(), "value_" + uuidv4());
 
     return this;
   };

--- a/apps/admin-ui/cypress/e2e/realm_settings_general_tab_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_general_tab_test.spec.ts
@@ -4,6 +4,7 @@ import RealmSettingsPage from "../support/pages/admin-ui/manage/realm_settings/R
 import Masthead from "../support/pages/admin-ui/Masthead";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -11,7 +12,7 @@ const masthead = new Masthead();
 const realmSettingsPage = new RealmSettingsPage();
 
 describe("Realm settings general tab tests", () => {
-  const realmName = "Realm_" + crypto.randomUUID();
+  const realmName = "Realm_" + uuidv4();
 
   beforeEach(() => {
     loginPage.logIn();

--- a/apps/admin-ui/cypress/e2e/realm_settings_tabs_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_tabs_test.spec.ts
@@ -4,6 +4,7 @@ import RealmSettingsPage from "../support/pages/admin-ui/manage/realm_settings/R
 import Masthead from "../support/pages/admin-ui/Masthead";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -11,7 +12,7 @@ const masthead = new Masthead();
 const realmSettingsPage = new RealmSettingsPage();
 
 describe("Realm settings tabs tests", () => {
-  const realmName = "Realm_" + crypto.randomUUID();
+  const realmName = "Realm_" + uuidv4();
 
   beforeEach(() => {
     loginPage.logIn();

--- a/apps/admin-ui/cypress/e2e/realm_settings_user_profile_tab.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_settings_user_profile_tab.spec.ts
@@ -6,6 +6,7 @@ import LoginPage from "../support/pages/LoginPage";
 import adminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import ModalUtils from "../support/util/ModalUtils";
+import { v4 as uuidv4 } from "uuid";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -23,7 +24,7 @@ const clickCreateAttributeButton = () =>
   userProfileTab.createAttributeButtonClick();
 
 describe("User profile tabs", () => {
-  const realmName = "Realm_" + crypto.randomUUID();
+  const realmName = "Realm_" + uuidv4();
   const attributeName = "Test";
 
   before(() =>

--- a/apps/admin-ui/cypress/e2e/realm_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/realm_test.spec.ts
@@ -6,7 +6,7 @@ import adminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import RealmSettings from "../support/pages/admin-ui/configure/realm_settings/RealmSettings";
 import ModalUtils from "../support/util/ModalUtils";
-
+import { v4 as uuidv4 } from "uuid";
 const masthead = new Masthead();
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -14,9 +14,9 @@ const createRealmPage = new CreateRealmPage();
 const realmSettings = new RealmSettings();
 const modalUtils = new ModalUtils();
 
-const testRealmName = "Test-realm-" + crypto.randomUUID();
-const newRealmName = "New-Test-realm-" + crypto.randomUUID();
-const editedRealmName = "Edited-Test-realm-" + crypto.randomUUID();
+const testRealmName = "Test-realm-" + uuidv4();
+const newRealmName = "New-Test-realm-" + uuidv4();
+const editedRealmName = "Edited-Test-realm-" + uuidv4();
 const testDisabledName = "Test-Disabled";
 
 describe("Realm tests", () => {

--- a/apps/admin-ui/cypress/e2e/users_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/users_test.spec.ts
@@ -12,6 +12,7 @@ import adminClient from "../support/util/AdminClient";
 import CredentialsPage from "../support/pages/admin-ui/manage/users/CredentialsPage";
 import UsersPage from "../support/pages/admin-ui/manage/users/UsersPage";
 import IdentityProviderLinksTab from "../support/pages/admin-ui/manage/users/user_details/tabs/IdentityProviderLinksTab";
+import { v4 as uuidv4 } from "uuid";
 
 let groupName = "group";
 let groupsList: string[] = [];
@@ -37,7 +38,7 @@ describe("User creation", () => {
 
   before(async () => {
     for (let i = 0; i <= 2; i++) {
-      groupName += "_" + crypto.randomUUID();
+      groupName += "_" + uuidv4();
       await adminClient.createGroup(groupName);
       groupsList = [...groupsList, groupName];
     }
@@ -61,7 +62,7 @@ describe("User creation", () => {
   });
 
   it("Create user test", () => {
-    itemId += "_" + crypto.randomUUID();
+    itemId += "_" + uuidv4();
     // Create
     createUserPage.goToCreateUser();
 
@@ -73,7 +74,7 @@ describe("User creation", () => {
   });
 
   it("Create user with groups test", () => {
-    itemIdWithGroups += crypto.randomUUID();
+    itemIdWithGroups += uuidv4();
     // Add user from search bar
     createUserPage.goToCreateUser();
 
@@ -95,7 +96,7 @@ describe("User creation", () => {
   });
 
   it("Create user with credentials test", () => {
-    itemIdWithCred += "_" + crypto.randomUUID();
+    itemIdWithCred += "_" + uuidv4();
 
     // Add user from search bar
     createUserPage.goToCreateUser();

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/users/user_details/UserDetailsPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/users/user_details/UserDetailsPage.ts
@@ -1,5 +1,6 @@
 import { RequiredActionAlias } from "@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderRepresentation";
 import PageObject from "../../../components/PageObject";
+import { v4 as uuidv4 } from "uuid";
 
 export default class UserDetailsPage extends PageObject {
   saveBtn: string;
@@ -18,8 +19,7 @@ export default class UserDetailsPage extends PageObject {
     this.saveBtn = "save-user";
     this.cancelBtn = "cancel-create-user";
     this.emailInput = "email-input";
-    this.emailValue = () =>
-      "example" + "_" + crypto.randomUUID() + "@example.com";
+    this.emailValue = () => "example" + "_" + uuidv4() + "@example.com";
     this.firstNameInput = "firstName-input";
     this.firstNameValue = "firstname";
     this.lastNameInput = "lastName-input";

--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -83,9 +83,11 @@
     "react-i18next": "^12.1.5",
     "react-router-dom": "6.8.1",
     "reactflow": "^11.5.6",
-    "use-react-router-breadcrumbs": "^4.0.1"
+    "use-react-router-breadcrumbs": "^4.0.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/uuid": "^9.0.1",
     "@4tw/cypress-drag-drop": "^2.2.3",
     "@testing-library/cypress": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.5",

--- a/apps/admin-ui/src/components/alert/Alerts.tsx
+++ b/apps/admin-ui/src/components/alert/Alerts.tsx
@@ -7,6 +7,7 @@ import { createNamedContext } from "../../utils/createNamedContext";
 import useRequiredContext from "../../utils/useRequiredContext";
 import useSetTimeout from "../../utils/useSetTimeout";
 import { AlertPanel } from "./AlertPanel";
+import { v4 as uuidv4 } from "uuid";
 
 const ALERT_TIMEOUT = 8000;
 
@@ -48,7 +49,7 @@ export const AlertProvider = ({ children }: PropsWithChildren) => {
   const addAlert = useCallback<AddAlertFunction>(
     (message, variant = AlertVariant.success, description) => {
       const alert: AlertEntry = {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         message,
         variant,
         description,

--- a/apps/admin-ui/src/components/dynamic/MapComponent.tsx
+++ b/apps/admin-ui/src/components/dynamic/MapComponent.tsx
@@ -16,6 +16,7 @@ import { HelpItem } from "../help-enabler/HelpItem";
 import { KeyValueType } from "../key-value-form/key-value-convert";
 import type { ComponentProps } from "./components";
 import { convertToName } from "./DynamicComponents";
+import { v4 as uuidv4 } from "uuid";
 
 type IdKeyValueType = KeyValueType & {
   id: string;
@@ -34,7 +35,7 @@ export const MapComponent = ({ name, label, helpText }: ComponentProps) => {
     if (!values.length) {
       values.push({ key: "", value: "" });
     }
-    setMap(values.map((value) => ({ ...value, id: crypto.randomUUID() })));
+    setMap(values.map((value) => ({ ...value, id: uuidv4() })));
   }, [register, getValues]);
 
   const update = (val = map) => {
@@ -128,7 +129,7 @@ export const MapComponent = ({ name, label, helpText }: ComponentProps) => {
             variant="link"
             icon={<PlusCircleIcon />}
             onClick={() =>
-              setMap([...map, { key: "", value: "", id: crypto.randomUUID() }])
+              setMap([...map, { key: "", value: "", id: uuidv4() }])
             }
           >
             {t("common:addAttribute")}

--- a/libs/ui-shared/src/alerts/Alerts.tsx
+++ b/libs/ui-shared/src/alerts/Alerts.tsx
@@ -6,6 +6,7 @@ import {
 } from "@patternfly/react-core";
 import { createContext, PropsWithChildren, useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { v4 as uuidv4 } from "uuid";
 
 export type AddAlertFunction = (
   message: string,
@@ -46,7 +47,7 @@ export const AlertProvider = ({ children }: PropsWithChildren) => {
   ) => {
     setAlerts([
       {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         //@ts-ignore
         message: t(message),
         variant,

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,8 @@
         "react-i18next": "^12.1.5",
         "react-router-dom": "6.8.1",
         "reactflow": "^11.5.6",
-        "use-react-router-breadcrumbs": "^4.0.1"
+        "use-react-router-breadcrumbs": "^4.0.1",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@4tw/cypress-drag-drop": "^2.2.3",
@@ -94,6 +95,7 @@
         "@types/lodash-es": "^4.17.6",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "@types/uuid": "^9.0.1",
         "@vitejs/plugin-react-swc": "^3.2.0",
         "cypress": "^12.6.0",
         "jsdom": "^21.1.0",
@@ -102,6 +104,14 @@
         "vite": "^4.1.2",
         "vite-plugin-checker": "^0.5.6",
         "vitest": "^0.28.5"
+      }
+    },
+    "apps/admin-ui/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "apps/keycloak-server": {
@@ -118,6 +128,7 @@
       "version": "999.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
+        "@keycloak/keycloak-admin-client": "^999.0.0-dev",
         "camelize-ts": "^2.3.0",
         "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
@@ -186,8 +197,6 @@
         "@vitejs/plugin-react-swc": "^3.2.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "vite": "^4.1.2",
-        "vite-plugin-checker": "^0.5.6",
-        "vite": "^4.1.1",
         "vite-plugin-checker": "^0.5.6",
         "vite-plugin-dts": "^1.7.3"
       }
@@ -2554,6 +2563,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.22",


### PR DESCRIPTION
## Motivation
Fixes #4442 
## Brief Description

The crypto.randomUUID() function that only works on pages using SSL was swapped in favor of the uuid library. It also implements the same rfc but is a zero dependency library which doesn't rely on a page having SSL

## Verification Steps

- Create users/groups etc. when there are alerts

## Testing

Keycloak has been tested in dev mode. I could create:
- clients
- users
- groups
- policies
- realms

on a domain pointing at 127.0.0.1 with the unsecure icon at the top. Alerts showed up everytime. So far there were no errors in the dev menu. Everything worked smoothly.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated


