### PR TITLE
Fix role restriction for OIDC Compatibility Modes

### DIFF
--- a/apps/admin-ui/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
+++ b/apps/admin-ui/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
@@ -22,7 +22,7 @@ export const OpenIdConnectCompatibilityModes = ({
   const { control } = useFormContext();
   return (
     <FormAccess
-      role="manage-realm"
+      role="manage-clients"
       fineGrainedAccess={hasConfigureAccess}
       isHorizontal
     >


### PR DESCRIPTION
## Motivation
Fixes #4451 

## Brief Description
Role restriction should be `manage-clients` and not `manage-realm`

## Verification Steps
See #4451 
