### PR TITLE
made the admin events test repeatable

### DIFF
--- a/apps/admin-ui/cypress/e2e/events_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/events_test.spec.ts
@@ -250,9 +250,15 @@ describe("Events tests", () => {
   });
 
   describe("Admin events list", () => {
+    const realmName = crypto.randomUUID();
+
+    before(() => adminClient.createRealm(realmName));
+    after(() => adminClient.deleteRealm(realmName));
+
     beforeEach(() => {
       loginPage.logIn();
       keycloakBefore();
+      sidebarPage.goToRealm(realmName);
       sidebarPage.goToEvents();
       eventsPage.goToAdminEventsTab();
     });

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_settings/tabs/realmsettings_events_subtabs/AdminEventsSettingsTab.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_settings/tabs/realmsettings_events_subtabs/AdminEventsSettingsTab.ts
@@ -13,7 +13,7 @@ export default class AdminEventsSettingsTab extends PageObject {
   clearAdminEvents() {
     cy.get(this.clearAdminEventsBtn).click();
     modal.checkModalTitle("Clear events");
-    cy.intercept("/admin/realms/master/admin-events").as("clearEvents");
+    cy.intercept("/admin/realms/*/admin-events").as("clearEvents");
     modal.confirmModal();
     cy.wait("@clearEvents");
     masthead.checkNotificationMessage("The admin events have been cleared");
@@ -42,9 +42,9 @@ export default class AdminEventsSettingsTab extends PageObject {
       waitForConfig: false,
     }
   ) {
-    waitForRealm && cy.intercept("/admin/realms/master").as("saveRealm");
+    waitForRealm && cy.intercept("/admin/realms/*").as("saveRealm");
     waitForConfig &&
-      cy.intercept("/admin/realms/master/events/config").as("saveConfig");
+      cy.intercept("/admin/realms/*/events/config").as("saveConfig");
 
     cy.get(this.saveBtn).click();
 


### PR DESCRIPTION
now creates a new realm to change the setting.
That way on failure it can retry

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
