### PR TITLE
Replace `GenerateId` component with React's `useId()` hook

### DIFF
--- a/apps/admin-ui/src/clients/keys/Certificate.tsx
+++ b/apps/admin-ui/src/clients/keys/Certificate.tsx
@@ -1,7 +1,8 @@
-import { useTranslation } from "react-i18next";
-import { FormGroup, GenerateId } from "@patternfly/react-core";
-
 import type CertificateRepresentation from "@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation";
+import { FormGroup } from "@patternfly/react-core";
+import { useId } from "react";
+import { useTranslation } from "react-i18next";
+
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { KeycloakTextArea } from "../../components/keycloak-text-area/KeycloakTextArea";
 
@@ -30,26 +31,22 @@ const CertificateDisplay = ({ id, keyInfo }: CertificateDisplayProps) => {
 
 export const Certificate = ({ keyInfo, plain = false }: CertificateProps) => {
   const { t } = useTranslation("clients");
-  return (
-    <GenerateId prefix="certificate">
-      {(id) =>
-        plain ? (
-          <CertificateDisplay id={id} keyInfo={keyInfo} />
-        ) : (
-          <FormGroup
-            label={t("certificate")}
-            fieldId={id}
-            labelIcon={
-              <HelpItem
-                helpText="clients-help:certificate"
-                fieldLabelId={`clients:${id}`}
-              />
-            }
-          >
-            <CertificateDisplay id={id} keyInfo={keyInfo} />
-          </FormGroup>
-        )
+  const id = useId();
+
+  return plain ? (
+    <CertificateDisplay id={id} keyInfo={keyInfo} />
+  ) : (
+    <FormGroup
+      label={t("certificate")}
+      fieldId={id}
+      labelIcon={
+        <HelpItem
+          helpText="clients-help:certificate"
+          fieldLabelId={`clients:${id}`}
+        />
       }
-    </GenerateId>
+    >
+      <CertificateDisplay id={id} keyInfo={keyInfo} />
+    </FormGroup>
   );
 };


### PR DESCRIPTION
Replaces PatternFly's `GenerateId` component with the new [`useId()` hook](https://beta.reactjs.org/reference/react/useId) from React.